### PR TITLE
LPS-166653

### DIFF
--- a/modules/apps/friendly-url/friendly-url-api/bnd.bnd
+++ b/modules/apps/friendly-url/friendly-url-api/bnd.bnd
@@ -1,6 +1,6 @@
 Bundle-Name: Liferay Friendly URL API
 Bundle-SymbolicName: com.liferay.friendly.url.api
-Bundle-Version: 5.1.2
+Bundle-Version: 6.0.0
 Export-Package:\
 	com.liferay.friendly.url.exception,\
 	com.liferay.friendly.url.info.item.provider,\

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalService.java
@@ -251,9 +251,14 @@ public interface FriendlyURLEntryLocalService
 	public FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, Class<?> clazz, String urlTitle);
 
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, String urlTitle);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String languageId, String urlTitle);
 
 	/**
 	 * Returns the friendly url entry matching the UUID and group.
@@ -266,9 +271,14 @@ public interface FriendlyURLEntryLocalService
 	public FriendlyURLEntry fetchFriendlyURLEntryByUuidAndGroupId(
 		String uuid, long groupId);
 
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
 		long groupId, long classNameId, String urlTitle);
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
+		long groupId, long classNameId, String languageId, String urlTitle);
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
@@ -361,9 +371,15 @@ public interface FriendlyURLEntryLocalService
 			String uuid, long groupId)
 		throws PortalException;
 
+	@Deprecated
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public FriendlyURLEntryLocalization getFriendlyURLEntryLocalization(
 			long groupId, long classNameId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public FriendlyURLEntryLocalization getFriendlyURLEntryLocalization(
+			long groupId, long classNameId, String languageId, String urlTitle)
 		throws NoSuchFriendlyURLEntryLocalizationException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
@@ -469,6 +485,11 @@ public interface FriendlyURLEntryLocalService
 
 	public void validate(
 			long groupId, long classNameId, long classPK, String urlTitle)
+		throws PortalException;
+
+	public void validate(
+			long groupId, long classNameId, long classPK, String languageId,
+			String urlTitle)
 		throws PortalException;
 
 	public void validate(long groupId, long classNameId, String urlTitle)

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceUtil.java
@@ -290,11 +290,19 @@ public class FriendlyURLEntryLocalServiceUtil {
 		return getService().fetchFriendlyURLEntry(groupId, clazz, urlTitle);
 	}
 
+	@Deprecated
 	public static FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, String urlTitle) {
 
 		return getService().fetchFriendlyURLEntry(
 			groupId, classNameId, urlTitle);
+	}
+
+	public static FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return getService().fetchFriendlyURLEntry(
+			groupId, classNameId, languageId, urlTitle);
 	}
 
 	/**
@@ -311,12 +319,22 @@ public class FriendlyURLEntryLocalServiceUtil {
 			uuid, groupId);
 	}
 
+	@Deprecated
 	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
 		fetchFriendlyURLEntryLocalization(
 			long groupId, long classNameId, String urlTitle) {
 
 		return getService().fetchFriendlyURLEntryLocalization(
 			groupId, classNameId, urlTitle);
+	}
+
+	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+		fetchFriendlyURLEntryLocalization(
+			long groupId, long classNameId, String languageId,
+			String urlTitle) {
+
+		return getService().fetchFriendlyURLEntryLocalization(
+			groupId, classNameId, languageId, urlTitle);
 	}
 
 	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
@@ -441,6 +459,7 @@ public class FriendlyURLEntryLocalServiceUtil {
 		return getService().getFriendlyURLEntryByUuidAndGroupId(uuid, groupId);
 	}
 
+	@Deprecated
 	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
 			getFriendlyURLEntryLocalization(
 				long groupId, long classNameId, String urlTitle)
@@ -449,6 +468,17 @@ public class FriendlyURLEntryLocalServiceUtil {
 
 		return getService().getFriendlyURLEntryLocalization(
 			groupId, classNameId, urlTitle);
+	}
+
+	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+			getFriendlyURLEntryLocalization(
+				long groupId, long classNameId, String languageId,
+				String urlTitle)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getService().getFriendlyURLEntryLocalization(
+			groupId, classNameId, languageId, urlTitle);
 	}
 
 	public static com.liferay.friendly.url.model.FriendlyURLEntryLocalization
@@ -625,6 +655,15 @@ public class FriendlyURLEntryLocalServiceUtil {
 		throws PortalException {
 
 		getService().validate(groupId, classNameId, classPK, urlTitle);
+	}
+
+	public static void validate(
+			long groupId, long classNameId, long classPK, String languageId,
+			String urlTitle)
+		throws PortalException {
+
+		getService().validate(
+			groupId, classNameId, classPK, languageId, urlTitle);
 	}
 
 	public static void validate(long groupId, long classNameId, String urlTitle)

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/FriendlyURLEntryLocalServiceWrapper.java
@@ -322,12 +322,21 @@ public class FriendlyURLEntryLocalServiceWrapper
 			groupId, clazz, urlTitle);
 	}
 
+	@Deprecated
 	@Override
 	public FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, String urlTitle) {
 
 		return _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
 			groupId, classNameId, urlTitle);
+	}
+
+	@Override
+	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return _friendlyURLEntryLocalService.fetchFriendlyURLEntry(
+			groupId, classNameId, languageId, urlTitle);
 	}
 
 	/**
@@ -345,6 +354,7 @@ public class FriendlyURLEntryLocalServiceWrapper
 			fetchFriendlyURLEntryByUuidAndGroupId(uuid, groupId);
 	}
 
+	@Deprecated
 	@Override
 	public com.liferay.friendly.url.model.FriendlyURLEntryLocalization
 		fetchFriendlyURLEntryLocalization(
@@ -352,6 +362,16 @@ public class FriendlyURLEntryLocalServiceWrapper
 
 		return _friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
 			groupId, classNameId, urlTitle);
+	}
+
+	@Override
+	public com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+		fetchFriendlyURLEntryLocalization(
+			long groupId, long classNameId, String languageId,
+			String urlTitle) {
+
+		return _friendlyURLEntryLocalService.fetchFriendlyURLEntryLocalization(
+			groupId, classNameId, languageId, urlTitle);
 	}
 
 	@Override
@@ -493,6 +513,7 @@ public class FriendlyURLEntryLocalServiceWrapper
 			getFriendlyURLEntryByUuidAndGroupId(uuid, groupId);
 	}
 
+	@Deprecated
 	@Override
 	public com.liferay.friendly.url.model.FriendlyURLEntryLocalization
 			getFriendlyURLEntryLocalization(
@@ -502,6 +523,18 @@ public class FriendlyURLEntryLocalServiceWrapper
 
 		return _friendlyURLEntryLocalService.getFriendlyURLEntryLocalization(
 			groupId, classNameId, urlTitle);
+	}
+
+	@Override
+	public com.liferay.friendly.url.model.FriendlyURLEntryLocalization
+			getFriendlyURLEntryLocalization(
+				long groupId, long classNameId, String languageId,
+				String urlTitle)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return _friendlyURLEntryLocalService.getFriendlyURLEntryLocalization(
+			groupId, classNameId, languageId, urlTitle);
 	}
 
 	@Override
@@ -701,6 +734,16 @@ public class FriendlyURLEntryLocalServiceWrapper
 
 		_friendlyURLEntryLocalService.validate(
 			groupId, classNameId, classPK, urlTitle);
+	}
+
+	@Override
+	public void validate(
+			long groupId, long classNameId, long classPK, String languageId,
+			String urlTitle)
+		throws com.liferay.portal.kernel.exception.PortalException {
+
+		_friendlyURLEntryLocalService.validate(
+			groupId, classNameId, classPK, languageId, urlTitle);
 	}
 
 	@Override

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationPersistence.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationPersistence.java
@@ -244,65 +244,6 @@ public interface FriendlyURLEntryLocalizationPersistence
 		long friendlyURLEntryId, String languageId);
 
 	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization
-	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
-	 */
-	public FriendlyURLEntryLocalization findByG_C_U(
-			long groupId, long classNameId, String urlTitle)
-		throws NoSuchFriendlyURLEntryLocalizationException;
-
-	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
-	 */
-	public FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle);
-
-	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
-	 */
-	public FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle,
-		boolean useFinderCache);
-
-	/**
-	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the friendly url entry localization that was removed
-	 */
-	public FriendlyURLEntryLocalization removeByG_C_U(
-			long groupId, long classNameId, String urlTitle)
-		throws NoSuchFriendlyURLEntryLocalizationException;
-
-	/**
-	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the number of matching friendly url entry localizations
-	 */
-	public int countByG_C_U(long groupId, long classNameId, String urlTitle);
-
-	/**
 	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and classPK = &#63; and languageId = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -484,6 +425,71 @@ public interface FriendlyURLEntryLocalizationPersistence
 	 */
 	public int countByG_C_C_L(
 		long groupId, long classNameId, long classPK, String languageId);
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization findByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle);
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		boolean useFinderCache);
+
+	/**
+	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the friendly url entry localization that was removed
+	 */
+	public FriendlyURLEntryLocalization removeByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException;
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	public int countByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle);
 
 	/**
 	 * Caches the friendly url entry localization in the entity cache if it is enabled.

--- a/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationUtil.java
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/java/com/liferay/friendly/url/service/persistence/FriendlyURLEntryLocalizationUtil.java
@@ -389,84 +389,6 @@ public class FriendlyURLEntryLocalizationUtil {
 	}
 
 	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization
-	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
-	 */
-	public static FriendlyURLEntryLocalization findByG_C_U(
-			long groupId, long classNameId, String urlTitle)
-		throws com.liferay.friendly.url.exception.
-			NoSuchFriendlyURLEntryLocalizationException {
-
-		return getPersistence().findByG_C_U(groupId, classNameId, urlTitle);
-	}
-
-	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
-	 */
-	public static FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle) {
-
-		return getPersistence().fetchByG_C_U(groupId, classNameId, urlTitle);
-	}
-
-	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
-	 */
-	public static FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle,
-		boolean useFinderCache) {
-
-		return getPersistence().fetchByG_C_U(
-			groupId, classNameId, urlTitle, useFinderCache);
-	}
-
-	/**
-	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the friendly url entry localization that was removed
-	 */
-	public static FriendlyURLEntryLocalization removeByG_C_U(
-			long groupId, long classNameId, String urlTitle)
-		throws com.liferay.friendly.url.exception.
-			NoSuchFriendlyURLEntryLocalizationException {
-
-		return getPersistence().removeByG_C_U(groupId, classNameId, urlTitle);
-	}
-
-	/**
-	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the number of matching friendly url entry localizations
-	 */
-	public static int countByG_C_U(
-		long groupId, long classNameId, String urlTitle) {
-
-		return getPersistence().countByG_C_U(groupId, classNameId, urlTitle);
-	}
-
-	/**
 	 * Returns all the friendly url entry localizations where groupId = &#63; and classNameId = &#63; and classPK = &#63; and languageId = &#63;.
 	 *
 	 * @param groupId the group ID
@@ -690,6 +612,93 @@ public class FriendlyURLEntryLocalizationUtil {
 
 		return getPersistence().countByG_C_C_L(
 			groupId, classNameId, classPK, languageId);
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization findByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().findByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return getPersistence().fetchByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	public static FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		boolean useFinderCache) {
+
+		return getPersistence().fetchByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle, useFinderCache);
+	}
+
+	/**
+	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the friendly url entry localization that was removed
+	 */
+	public static FriendlyURLEntryLocalization removeByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws com.liferay.friendly.url.exception.
+			NoSuchFriendlyURLEntryLocalizationException {
+
+		return getPersistence().removeByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle);
+	}
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	public static int countByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return getPersistence().countByG_C_L_U(
+			groupId, classNameId, languageId, urlTitle);
 	}
 
 	/**

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/packageinfo
@@ -1,1 +1,1 @@
-version 1.6.0
+version 1.7.0

--- a/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/persistence/packageinfo
+++ b/modules/apps/friendly-url/friendly-url-api/src/main/resources/com/liferay/friendly/url/service/persistence/packageinfo
@@ -1,1 +1,1 @@
-version 3.1.0
+version 4.0.0

--- a/modules/apps/friendly-url/friendly-url-service/service.xml
+++ b/modules/apps/friendly-url/friendly-url-service/service.xml
@@ -34,16 +34,17 @@
 
 			<!-- Finder methods -->
 
-			<finder name="G_C_U" return-type="FriendlyURLEntryLocalization" unique="true">
-				<finder-column name="groupId" />
-				<finder-column name="classNameId" />
-				<finder-column name="urlTitle" />
-			</finder>
 			<finder name="G_C_C_L" return-type="Collection">
 				<finder-column name="groupId" />
 				<finder-column name="classNameId" />
 				<finder-column name="classPK" />
 				<finder-column name="languageId" />
+			</finder>
+			<finder name="G_C_L_U" return-type="FriendlyURLEntryLocalization" unique="true">
+				<finder-column name="groupId" />
+				<finder-column name="classNameId" />
+				<finder-column name="languageId" />
+				<finder-column name="urlTitle" />
 			</finder>
 		</localized-entity>
 

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -34,10 +34,12 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
+import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
+import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -308,12 +310,16 @@ public class FriendlyURLEntryLocalServiceImpl
 	}
 
 	@Override
+	@Deprecated
 	public FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, String urlTitle) {
 
+		String defaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
+
 		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-			friendlyURLEntryLocalizationPersistence.fetchByG_C_U(
-				groupId, classNameId,
+			friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
+				groupId, classNameId, defaultLanguageId,
 				_friendlyURLNormalizer.normalizeWithEncoding(urlTitle));
 
 		if (friendlyURLEntryLocalization != null) {
@@ -325,11 +331,42 @@ public class FriendlyURLEntryLocalServiceImpl
 	}
 
 	@Override
+	public FriendlyURLEntry fetchFriendlyURLEntry(
+		long groupId, long classNameId,String languageId, String urlTitle) {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
+				groupId, classNameId, languageId,
+				_friendlyURLNormalizer.normalizeWithEncoding(urlTitle));
+
+		if (friendlyURLEntryLocalization != null) {
+			return friendlyURLEntryPersistence.fetchByPrimaryKey(
+				friendlyURLEntryLocalization.getFriendlyURLEntryId());
+		}
+
+		return null;
+	}
+
+
+	@Override
+	@Deprecated
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
 		long groupId, long classNameId, String urlTitle) {
 
-		return friendlyURLEntryLocalizationPersistence.fetchByG_C_U(
-			groupId, classNameId,
+		String defaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
+
+		return friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
+			groupId, classNameId, defaultLanguageId,
+			_friendlyURLNormalizer.normalizeWithEncoding(urlTitle));
+	}
+
+	@Override
+	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
+		long groupId, long classNameId,String languageId, String urlTitle) {
+
+		return friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
+			groupId, classNameId, languageId,
 			_friendlyURLNormalizer.normalizeWithEncoding(urlTitle));
 	}
 
@@ -358,12 +395,25 @@ public class FriendlyURLEntryLocalServiceImpl
 	}
 
 	@Override
+	@Deprecated
 	public FriendlyURLEntryLocalization getFriendlyURLEntryLocalization(
 			long groupId, long classNameId, String urlTitle)
 		throws NoSuchFriendlyURLEntryLocalizationException {
+		String defaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
 
-		return friendlyURLEntryLocalizationPersistence.findByG_C_U(
-			groupId, classNameId,
+		return friendlyURLEntryLocalizationPersistence.findByG_C_L_U(
+			groupId, classNameId, defaultLanguageId,
+			_friendlyURLNormalizer.normalizeWithEncoding(urlTitle));
+	}
+
+	@Override
+	public FriendlyURLEntryLocalization getFriendlyURLEntryLocalization(
+		long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		return friendlyURLEntryLocalizationPersistence.findByG_C_L_U(
+			groupId, classNameId, languageId,
 			_friendlyURLNormalizer.normalizeWithEncoding(urlTitle));
 	}
 
@@ -433,8 +483,8 @@ public class FriendlyURLEntryLocalServiceImpl
 
 		for (int i = 1;; i++) {
 			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-				friendlyURLEntryLocalizationPersistence.fetchByG_C_U(
-					groupId, classNameId, curUrlTitle);
+				friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
+					groupId, classNameId, languageId,curUrlTitle);
 
 			if (Validator.isNull(languageId)) {
 				if ((friendlyURLEntryLocalization == null) ||
@@ -547,14 +597,14 @@ public class FriendlyURLEntryLocalServiceImpl
 			Map<String, String> urlTitleMap)
 		throws PortalException {
 
-		for (String urlTitle : urlTitleMap.values()) {
-			validate(groupId, classNameId, classPK, urlTitle);
+		for (String urlKey : urlTitleMap.keySet()) {
+			validate(groupId, classNameId, classPK,urlKey, urlTitleMap.get(urlKey));
 		}
 	}
 
 	@Override
 	public void validate(
-			long groupId, long classNameId, long classPK, String urlTitle)
+			long groupId, long classNameId, long classPK, String languageId, String urlTitle)
 		throws PortalException {
 
 		int maxLength = ModelHintsUtil.getMaxLength(
@@ -569,8 +619,8 @@ public class FriendlyURLEntryLocalServiceImpl
 		}
 
 		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-			friendlyURLEntryLocalizationPersistence.fetchByG_C_U(
-				groupId, classNameId, normalizedUrlTitle);
+			friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
+				groupId, classNameId, languageId,normalizedUrlTitle);
 
 		if (friendlyURLEntryLocalization == null) {
 			return;
@@ -587,9 +637,19 @@ public class FriendlyURLEntryLocalServiceImpl
 	@Override
 	public void validate(long groupId, long classNameId, String urlTitle)
 		throws PortalException {
+		String defaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
 
-		validate(groupId, classNameId, 0, urlTitle);
+		validate(groupId, classNameId, 0, defaultLanguageId ,urlTitle);
 	}
+
+	@Override
+	public void validate(long groupId, long classNameId, long classPK,String urlTitle)
+		throws PortalException {
+
+		validate(groupId, classNameId, 0, languageId, urlTitle);
+	}
+
 
 	private boolean _containsAllURLTitles(
 		Map<String, String> existingUrlTitleMap,
@@ -693,8 +753,8 @@ public class FriendlyURLEntryLocalServiceImpl
 			if (Validator.isNotNull(normalizedUrlTitle)) {
 				FriendlyURLEntryLocalization
 					existingFriendlyURLEntryLocalization =
-						friendlyURLEntryLocalizationPersistence.fetchByG_C_U(
-							friendlyURLEntry.getGroupId(), classNameId,
+						friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
+							friendlyURLEntry.getGroupId(), classNameId,entry.getKey(),
 							normalizedUrlTitle);
 
 				if (existingFriendlyURLEntryLocalization != null) {
@@ -727,8 +787,8 @@ public class FriendlyURLEntryLocalServiceImpl
 				}
 
 				FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-					friendlyURLEntryLocalizationPersistence.fetchByG_C_U(
-						friendlyURLEntry.getGroupId(), classNameId,
+					friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
+						friendlyURLEntry.getGroupId(), classNameId,entry.getKey(),
 						normalizedUrlTitle);
 
 				if (friendlyURLEntryLocalization != null) {

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -492,6 +492,10 @@ public class FriendlyURLEntryLocalServiceImpl
 		String prefix = curUrlTitle;
 
 		for (int i = 1;; i++) {
+			if(Validator.isNull(languageId)){
+				languageId = LocaleUtil.toLanguageId(
+					LocaleUtil.getSiteDefault());
+			}
 			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
 				friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
 					groupId, classNameId, languageId, curUrlTitle);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -34,12 +34,10 @@ import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.ModelHintsUtil;
-import com.liferay.portal.kernel.security.auth.CompanyThreadLocal;
 import com.liferay.portal.kernel.service.ClassNameLocalService;
 import com.liferay.portal.kernel.service.GroupLocalService;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.util.FriendlyURLNormalizer;
-import com.liferay.portal.kernel.util.GroupThreadLocal;
 import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.OrderByComparator;
@@ -309,8 +307,12 @@ public class FriendlyURLEntryLocalServiceImpl
 			groupId, _classNameLocalService.getClassNameId(clazz), urlTitle);
 	}
 
-	@Override
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #fetchFriendlyURLEntry(long, long, String, String)}
+	 */
 	@Deprecated
+	@Override
 	public FriendlyURLEntry fetchFriendlyURLEntry(
 		long groupId, long classNameId, String urlTitle) {
 
@@ -332,7 +334,7 @@ public class FriendlyURLEntryLocalServiceImpl
 
 	@Override
 	public FriendlyURLEntry fetchFriendlyURLEntry(
-		long groupId, long classNameId,String languageId, String urlTitle) {
+		long groupId, long classNameId, String languageId, String urlTitle) {
 
 		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
 			friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
@@ -347,9 +349,12 @@ public class FriendlyURLEntryLocalServiceImpl
 		return null;
 	}
 
-
-	@Override
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #fetchFriendlyURLEntryLocalization(long, long, String, String)}
+	 */
 	@Deprecated
+	@Override
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
 		long groupId, long classNameId, String urlTitle) {
 
@@ -363,7 +368,7 @@ public class FriendlyURLEntryLocalServiceImpl
 
 	@Override
 	public FriendlyURLEntryLocalization fetchFriendlyURLEntryLocalization(
-		long groupId, long classNameId,String languageId, String urlTitle) {
+		long groupId, long classNameId, String languageId, String urlTitle) {
 
 		return friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
 			groupId, classNameId, languageId,
@@ -394,11 +399,16 @@ public class FriendlyURLEntryLocalServiceImpl
 			groupId, classNameId, classPK);
 	}
 
-	@Override
+	/**
+	 * @deprecated As of Cavanaugh (7.4.x), replaced by {@link
+	 *             #getFriendlyURLEntryLocalization(long, long, String, String)}
+	 */
 	@Deprecated
+	@Override
 	public FriendlyURLEntryLocalization getFriendlyURLEntryLocalization(
 			long groupId, long classNameId, String urlTitle)
 		throws NoSuchFriendlyURLEntryLocalizationException {
+
 		String defaultLanguageId = LocaleUtil.toLanguageId(
 			LocaleUtil.getSiteDefault());
 
@@ -409,7 +419,7 @@ public class FriendlyURLEntryLocalServiceImpl
 
 	@Override
 	public FriendlyURLEntryLocalization getFriendlyURLEntryLocalization(
-		long groupId, long classNameId, String languageId, String urlTitle)
+			long groupId, long classNameId, String languageId, String urlTitle)
 		throws NoSuchFriendlyURLEntryLocalizationException {
 
 		return friendlyURLEntryLocalizationPersistence.findByG_C_L_U(
@@ -484,7 +494,7 @@ public class FriendlyURLEntryLocalServiceImpl
 		for (int i = 1;; i++) {
 			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
 				friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
-					groupId, classNameId, languageId,curUrlTitle);
+					groupId, classNameId, languageId, curUrlTitle);
 
 			if (Validator.isNull(languageId)) {
 				if ((friendlyURLEntryLocalization == null) ||
@@ -597,14 +607,28 @@ public class FriendlyURLEntryLocalServiceImpl
 			Map<String, String> urlTitleMap)
 		throws PortalException {
 
-		for (String urlKey : urlTitleMap.keySet()) {
-			validate(groupId, classNameId, classPK,urlKey, urlTitleMap.get(urlKey));
+		for (Map.Entry<String, String> entry : urlTitleMap.entrySet()) {
+			validate(
+				groupId, classNameId, classPK, entry.getKey(),
+				entry.getValue());
 		}
 	}
 
 	@Override
 	public void validate(
-			long groupId, long classNameId, long classPK, String languageId, String urlTitle)
+			long groupId, long classNameId, long classPK, String urlTitle)
+		throws PortalException {
+
+		String defaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
+
+		validate(groupId, classNameId, 0, defaultLanguageId, urlTitle);
+	}
+
+	@Override
+	public void validate(
+			long groupId, long classNameId, long classPK, String languageId,
+			String urlTitle)
 		throws PortalException {
 
 		int maxLength = ModelHintsUtil.getMaxLength(
@@ -620,7 +644,7 @@ public class FriendlyURLEntryLocalServiceImpl
 
 		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
 			friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
-				groupId, classNameId, languageId,normalizedUrlTitle);
+				groupId, classNameId, languageId, normalizedUrlTitle);
 
 		if (friendlyURLEntryLocalization == null) {
 			return;
@@ -637,21 +661,12 @@ public class FriendlyURLEntryLocalServiceImpl
 	@Override
 	public void validate(long groupId, long classNameId, String urlTitle)
 		throws PortalException {
-		String defaultLanguageId = LocaleUtil.toLanguageId(
-			LocaleUtil.getSiteDefault());
 
-		validate(groupId, classNameId, 0, defaultLanguageId ,urlTitle);
-	}
-
-	@Override
-	public void validate(long groupId, long classNameId, long classPK,String urlTitle)
-		throws PortalException {
 		String defaultLanguageId = LocaleUtil.toLanguageId(
 			LocaleUtil.getSiteDefault());
 
 		validate(groupId, classNameId, 0, defaultLanguageId, urlTitle);
 	}
-
 
 	private boolean _containsAllURLTitles(
 		Map<String, String> existingUrlTitleMap,
@@ -756,15 +771,12 @@ public class FriendlyURLEntryLocalServiceImpl
 				FriendlyURLEntryLocalization
 					existingFriendlyURLEntryLocalization =
 						friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
-							friendlyURLEntry.getGroupId(), classNameId,entry.getKey(),
-							normalizedUrlTitle);
+							friendlyURLEntry.getGroupId(), classNameId,
+							entry.getKey(), normalizedUrlTitle);
 
 				if (existingFriendlyURLEntryLocalization != null) {
-					String existingLanguageId =
-						existingFriendlyURLEntryLocalization.getLanguageId();
-
-					if ((existingFriendlyURLEntryLocalization.getClassPK() ==
-							classPK)) {
+					if (existingFriendlyURLEntryLocalization.getClassPK() ==
+							classPK) {
 
 						String existingUrlTitle =
 							existingFriendlyURLEntryLocalization.getUrlTitle();
@@ -787,21 +799,8 @@ public class FriendlyURLEntryLocalServiceImpl
 					}
 				}
 
-				FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-					friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
-						friendlyURLEntry.getGroupId(), classNameId,entry.getKey(),
-						normalizedUrlTitle);
-
-				if (friendlyURLEntryLocalization != null) {
-					friendlyURLEntryLocalization.setFriendlyURLEntryId(
-						friendlyURLEntry.getFriendlyURLEntryId());
-
-					updateFriendlyURLLocalization(friendlyURLEntryLocalization);
-				}
-				else {
-					updateFriendlyURLEntryLocalization(
-						friendlyURLEntry, entry.getKey(), normalizedUrlTitle);
-				}
+				updateFriendlyURLEntryLocalization(
+					friendlyURLEntry, entry.getKey(), normalizedUrlTitle);
 			}
 			else if ((normalizedUrlTitle != null) &&
 					 normalizedUrlTitle.equals(StringPool.BLANK)) {

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -646,8 +646,10 @@ public class FriendlyURLEntryLocalServiceImpl
 	@Override
 	public void validate(long groupId, long classNameId, long classPK,String urlTitle)
 		throws PortalException {
+		String defaultLanguageId = LocaleUtil.toLanguageId(
+			LocaleUtil.getSiteDefault());
 
-		validate(groupId, classNameId, 0, languageId, urlTitle);
+		validate(groupId, classNameId, 0, defaultLanguageId, urlTitle);
 	}
 
 
@@ -762,8 +764,7 @@ public class FriendlyURLEntryLocalServiceImpl
 						existingFriendlyURLEntryLocalization.getLanguageId();
 
 					if ((existingFriendlyURLEntryLocalization.getClassPK() ==
-							classPK) &&
-						existingLanguageId.equals(entry.getKey())) {
+							classPK)) {
 
 						String existingUrlTitle =
 							existingFriendlyURLEntryLocalization.getUrlTitle();

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/impl/FriendlyURLEntryLocalServiceImpl.java
@@ -492,10 +492,11 @@ public class FriendlyURLEntryLocalServiceImpl
 		String prefix = curUrlTitle;
 
 		for (int i = 1;; i++) {
-			if(Validator.isNull(languageId)){
+			if (Validator.isNull(languageId)) {
 				languageId = LocaleUtil.toLanguageId(
 					LocaleUtil.getSiteDefault());
 			}
+
 			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
 				friendlyURLEntryLocalizationPersistence.fetchByG_C_L_U(
 					groupId, classNameId, languageId, curUrlTitle);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryLocalizationPersistenceImpl.java
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/java/com/liferay/friendly/url/service/persistence/impl/FriendlyURLEntryLocalizationPersistenceImpl.java
@@ -929,301 +929,6 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 		_FINDER_COLUMN_FRIENDLYURLENTRYID_LANGUAGEID_LANGUAGEID_3 =
 			"(friendlyURLEntryLocalization.languageId IS NULL OR friendlyURLEntryLocalization.languageId = '')";
 
-	private FinderPath _finderPathFetchByG_C_U;
-	private FinderPath _finderPathCountByG_C_U;
-
-	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization
-	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
-	 */
-	@Override
-	public FriendlyURLEntryLocalization findByG_C_U(
-			long groupId, long classNameId, String urlTitle)
-		throws NoSuchFriendlyURLEntryLocalizationException {
-
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-			fetchByG_C_U(groupId, classNameId, urlTitle);
-
-		if (friendlyURLEntryLocalization == null) {
-			StringBundler sb = new StringBundler(8);
-
-			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
-
-			sb.append("groupId=");
-			sb.append(groupId);
-
-			sb.append(", classNameId=");
-			sb.append(classNameId);
-
-			sb.append(", urlTitle=");
-			sb.append(urlTitle);
-
-			sb.append("}");
-
-			if (_log.isDebugEnabled()) {
-				_log.debug(sb.toString());
-			}
-
-			throw new NoSuchFriendlyURLEntryLocalizationException(
-				sb.toString());
-		}
-
-		return friendlyURLEntryLocalization;
-	}
-
-	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
-	 */
-	@Override
-	public FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle) {
-
-		return fetchByG_C_U(groupId, classNameId, urlTitle, true);
-	}
-
-	/**
-	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @param useFinderCache whether to use the finder cache
-	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
-	 */
-	@Override
-	public FriendlyURLEntryLocalization fetchByG_C_U(
-		long groupId, long classNameId, String urlTitle,
-		boolean useFinderCache) {
-
-		urlTitle = Objects.toString(urlTitle, "");
-
-		boolean productionMode = ctPersistenceHelper.isProductionMode(
-			FriendlyURLEntryLocalization.class);
-
-		Object[] finderArgs = null;
-
-		if (useFinderCache && productionMode) {
-			finderArgs = new Object[] {groupId, classNameId, urlTitle};
-		}
-
-		Object result = null;
-
-		if (useFinderCache && productionMode) {
-			result = finderCache.getResult(
-				_finderPathFetchByG_C_U, finderArgs, this);
-		}
-
-		if (result instanceof FriendlyURLEntryLocalization) {
-			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-				(FriendlyURLEntryLocalization)result;
-
-			if ((groupId != friendlyURLEntryLocalization.getGroupId()) ||
-				(classNameId !=
-					friendlyURLEntryLocalization.getClassNameId()) ||
-				!Objects.equals(
-					urlTitle, friendlyURLEntryLocalization.getUrlTitle())) {
-
-				result = null;
-			}
-		}
-
-		if (result == null) {
-			StringBundler sb = new StringBundler(5);
-
-			sb.append(_SQL_SELECT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
-
-			sb.append(_FINDER_COLUMN_G_C_U_GROUPID_2);
-
-			sb.append(_FINDER_COLUMN_G_C_U_CLASSNAMEID_2);
-
-			boolean bindUrlTitle = false;
-
-			if (urlTitle.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_C_U_URLTITLE_3);
-			}
-			else {
-				bindUrlTitle = true;
-
-				sb.append(_FINDER_COLUMN_G_C_U_URLTITLE_2);
-			}
-
-			String sql = sb.toString();
-
-			Session session = null;
-
-			try {
-				session = openSession();
-
-				Query query = session.createQuery(sql);
-
-				QueryPos queryPos = QueryPos.getInstance(query);
-
-				queryPos.add(groupId);
-
-				queryPos.add(classNameId);
-
-				if (bindUrlTitle) {
-					queryPos.add(urlTitle);
-				}
-
-				List<FriendlyURLEntryLocalization> list = query.list();
-
-				if (list.isEmpty()) {
-					if (useFinderCache && productionMode) {
-						finderCache.putResult(
-							_finderPathFetchByG_C_U, finderArgs, list);
-					}
-				}
-				else {
-					FriendlyURLEntryLocalization friendlyURLEntryLocalization =
-						list.get(0);
-
-					result = friendlyURLEntryLocalization;
-
-					cacheResult(friendlyURLEntryLocalization);
-				}
-			}
-			catch (Exception exception) {
-				throw processException(exception);
-			}
-			finally {
-				closeSession(session);
-			}
-		}
-
-		if (result instanceof List<?>) {
-			return null;
-		}
-		else {
-			return (FriendlyURLEntryLocalization)result;
-		}
-	}
-
-	/**
-	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and urlTitle = &#63; from the database.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the friendly url entry localization that was removed
-	 */
-	@Override
-	public FriendlyURLEntryLocalization removeByG_C_U(
-			long groupId, long classNameId, String urlTitle)
-		throws NoSuchFriendlyURLEntryLocalizationException {
-
-		FriendlyURLEntryLocalization friendlyURLEntryLocalization = findByG_C_U(
-			groupId, classNameId, urlTitle);
-
-		return remove(friendlyURLEntryLocalization);
-	}
-
-	/**
-	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and urlTitle = &#63;.
-	 *
-	 * @param groupId the group ID
-	 * @param classNameId the class name ID
-	 * @param urlTitle the url title
-	 * @return the number of matching friendly url entry localizations
-	 */
-	@Override
-	public int countByG_C_U(long groupId, long classNameId, String urlTitle) {
-		urlTitle = Objects.toString(urlTitle, "");
-
-		boolean productionMode = ctPersistenceHelper.isProductionMode(
-			FriendlyURLEntryLocalization.class);
-
-		FinderPath finderPath = null;
-		Object[] finderArgs = null;
-
-		Long count = null;
-
-		if (productionMode) {
-			finderPath = _finderPathCountByG_C_U;
-
-			finderArgs = new Object[] {groupId, classNameId, urlTitle};
-
-			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
-		}
-
-		if (count == null) {
-			StringBundler sb = new StringBundler(4);
-
-			sb.append(_SQL_COUNT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
-
-			sb.append(_FINDER_COLUMN_G_C_U_GROUPID_2);
-
-			sb.append(_FINDER_COLUMN_G_C_U_CLASSNAMEID_2);
-
-			boolean bindUrlTitle = false;
-
-			if (urlTitle.isEmpty()) {
-				sb.append(_FINDER_COLUMN_G_C_U_URLTITLE_3);
-			}
-			else {
-				bindUrlTitle = true;
-
-				sb.append(_FINDER_COLUMN_G_C_U_URLTITLE_2);
-			}
-
-			String sql = sb.toString();
-
-			Session session = null;
-
-			try {
-				session = openSession();
-
-				Query query = session.createQuery(sql);
-
-				QueryPos queryPos = QueryPos.getInstance(query);
-
-				queryPos.add(groupId);
-
-				queryPos.add(classNameId);
-
-				if (bindUrlTitle) {
-					queryPos.add(urlTitle);
-				}
-
-				count = (Long)query.uniqueResult();
-
-				if (productionMode) {
-					finderCache.putResult(finderPath, finderArgs, count);
-				}
-			}
-			catch (Exception exception) {
-				throw processException(exception);
-			}
-			finally {
-				closeSession(session);
-			}
-		}
-
-		return count.intValue();
-	}
-
-	private static final String _FINDER_COLUMN_G_C_U_GROUPID_2 =
-		"friendlyURLEntryLocalization.groupId = ? AND ";
-
-	private static final String _FINDER_COLUMN_G_C_U_CLASSNAMEID_2 =
-		"friendlyURLEntryLocalization.classNameId = ? AND ";
-
-	private static final String _FINDER_COLUMN_G_C_U_URLTITLE_2 =
-		"friendlyURLEntryLocalization.urlTitle = ?";
-
-	private static final String _FINDER_COLUMN_G_C_U_URLTITLE_3 =
-		"(friendlyURLEntryLocalization.urlTitle IS NULL OR friendlyURLEntryLocalization.urlTitle = '')";
-
 	private FinderPath _finderPathWithPaginationFindByG_C_C_L;
 	private FinderPath _finderPathWithoutPaginationFindByG_C_C_L;
 	private FinderPath _finderPathCountByG_C_C_L;
@@ -1918,6 +1623,355 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 	private static final String _FINDER_COLUMN_G_C_C_L_LANGUAGEID_3 =
 		"(friendlyURLEntryLocalization.languageId IS NULL OR friendlyURLEntryLocalization.languageId = '')";
 
+	private FinderPath _finderPathFetchByG_C_L_U;
+	private FinderPath _finderPathCountByG_C_L_U;
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or throws a <code>NoSuchFriendlyURLEntryLocalizationException</code> if it could not be found.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization
+	 * @throws NoSuchFriendlyURLEntryLocalizationException if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization findByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			fetchByG_C_L_U(groupId, classNameId, languageId, urlTitle);
+
+		if (friendlyURLEntryLocalization == null) {
+			StringBundler sb = new StringBundler(10);
+
+			sb.append(_NO_SUCH_ENTITY_WITH_KEY);
+
+			sb.append("groupId=");
+			sb.append(groupId);
+
+			sb.append(", classNameId=");
+			sb.append(classNameId);
+
+			sb.append(", languageId=");
+			sb.append(languageId);
+
+			sb.append(", urlTitle=");
+			sb.append(urlTitle);
+
+			sb.append("}");
+
+			if (_log.isDebugEnabled()) {
+				_log.debug(sb.toString());
+			}
+
+			throw new NoSuchFriendlyURLEntryLocalizationException(
+				sb.toString());
+		}
+
+		return friendlyURLEntryLocalization;
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found. Uses the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		return fetchByG_C_L_U(groupId, classNameId, languageId, urlTitle, true);
+	}
+
+	/**
+	 * Returns the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; or returns <code>null</code> if it could not be found, optionally using the finder cache.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @param useFinderCache whether to use the finder cache
+	 * @return the matching friendly url entry localization, or <code>null</code> if a matching friendly url entry localization could not be found
+	 */
+	@Override
+	public FriendlyURLEntryLocalization fetchByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle,
+		boolean useFinderCache) {
+
+		languageId = Objects.toString(languageId, "");
+		urlTitle = Objects.toString(urlTitle, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			FriendlyURLEntryLocalization.class);
+
+		Object[] finderArgs = null;
+
+		if (useFinderCache && productionMode) {
+			finderArgs = new Object[] {
+				groupId, classNameId, languageId, urlTitle
+			};
+		}
+
+		Object result = null;
+
+		if (useFinderCache && productionMode) {
+			result = finderCache.getResult(
+				_finderPathFetchByG_C_L_U, finderArgs, this);
+		}
+
+		if (result instanceof FriendlyURLEntryLocalization) {
+			FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+				(FriendlyURLEntryLocalization)result;
+
+			if ((groupId != friendlyURLEntryLocalization.getGroupId()) ||
+				(classNameId !=
+					friendlyURLEntryLocalization.getClassNameId()) ||
+				!Objects.equals(
+					languageId, friendlyURLEntryLocalization.getLanguageId()) ||
+				!Objects.equals(
+					urlTitle, friendlyURLEntryLocalization.getUrlTitle())) {
+
+				result = null;
+			}
+		}
+
+		if (result == null) {
+			StringBundler sb = new StringBundler(6);
+
+			sb.append(_SQL_SELECT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_L_U_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_L_U_CLASSNAMEID_2);
+
+			boolean bindLanguageId = false;
+
+			if (languageId.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_L_U_LANGUAGEID_3);
+			}
+			else {
+				bindLanguageId = true;
+
+				sb.append(_FINDER_COLUMN_G_C_L_U_LANGUAGEID_2);
+			}
+
+			boolean bindUrlTitle = false;
+
+			if (urlTitle.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_L_U_URLTITLE_3);
+			}
+			else {
+				bindUrlTitle = true;
+
+				sb.append(_FINDER_COLUMN_G_C_L_U_URLTITLE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindLanguageId) {
+					queryPos.add(languageId);
+				}
+
+				if (bindUrlTitle) {
+					queryPos.add(urlTitle);
+				}
+
+				List<FriendlyURLEntryLocalization> list = query.list();
+
+				if (list.isEmpty()) {
+					if (useFinderCache && productionMode) {
+						finderCache.putResult(
+							_finderPathFetchByG_C_L_U, finderArgs, list);
+					}
+				}
+				else {
+					FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+						list.get(0);
+
+					result = friendlyURLEntryLocalization;
+
+					cacheResult(friendlyURLEntryLocalization);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		if (result instanceof List<?>) {
+			return null;
+		}
+		else {
+			return (FriendlyURLEntryLocalization)result;
+		}
+	}
+
+	/**
+	 * Removes the friendly url entry localization where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63; from the database.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the friendly url entry localization that was removed
+	 */
+	@Override
+	public FriendlyURLEntryLocalization removeByG_C_L_U(
+			long groupId, long classNameId, String languageId, String urlTitle)
+		throws NoSuchFriendlyURLEntryLocalizationException {
+
+		FriendlyURLEntryLocalization friendlyURLEntryLocalization =
+			findByG_C_L_U(groupId, classNameId, languageId, urlTitle);
+
+		return remove(friendlyURLEntryLocalization);
+	}
+
+	/**
+	 * Returns the number of friendly url entry localizations where groupId = &#63; and classNameId = &#63; and languageId = &#63; and urlTitle = &#63;.
+	 *
+	 * @param groupId the group ID
+	 * @param classNameId the class name ID
+	 * @param languageId the language ID
+	 * @param urlTitle the url title
+	 * @return the number of matching friendly url entry localizations
+	 */
+	@Override
+	public int countByG_C_L_U(
+		long groupId, long classNameId, String languageId, String urlTitle) {
+
+		languageId = Objects.toString(languageId, "");
+		urlTitle = Objects.toString(urlTitle, "");
+
+		boolean productionMode = ctPersistenceHelper.isProductionMode(
+			FriendlyURLEntryLocalization.class);
+
+		FinderPath finderPath = null;
+		Object[] finderArgs = null;
+
+		Long count = null;
+
+		if (productionMode) {
+			finderPath = _finderPathCountByG_C_L_U;
+
+			finderArgs = new Object[] {
+				groupId, classNameId, languageId, urlTitle
+			};
+
+			count = (Long)finderCache.getResult(finderPath, finderArgs, this);
+		}
+
+		if (count == null) {
+			StringBundler sb = new StringBundler(5);
+
+			sb.append(_SQL_COUNT_FRIENDLYURLENTRYLOCALIZATION_WHERE);
+
+			sb.append(_FINDER_COLUMN_G_C_L_U_GROUPID_2);
+
+			sb.append(_FINDER_COLUMN_G_C_L_U_CLASSNAMEID_2);
+
+			boolean bindLanguageId = false;
+
+			if (languageId.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_L_U_LANGUAGEID_3);
+			}
+			else {
+				bindLanguageId = true;
+
+				sb.append(_FINDER_COLUMN_G_C_L_U_LANGUAGEID_2);
+			}
+
+			boolean bindUrlTitle = false;
+
+			if (urlTitle.isEmpty()) {
+				sb.append(_FINDER_COLUMN_G_C_L_U_URLTITLE_3);
+			}
+			else {
+				bindUrlTitle = true;
+
+				sb.append(_FINDER_COLUMN_G_C_L_U_URLTITLE_2);
+			}
+
+			String sql = sb.toString();
+
+			Session session = null;
+
+			try {
+				session = openSession();
+
+				Query query = session.createQuery(sql);
+
+				QueryPos queryPos = QueryPos.getInstance(query);
+
+				queryPos.add(groupId);
+
+				queryPos.add(classNameId);
+
+				if (bindLanguageId) {
+					queryPos.add(languageId);
+				}
+
+				if (bindUrlTitle) {
+					queryPos.add(urlTitle);
+				}
+
+				count = (Long)query.uniqueResult();
+
+				if (productionMode) {
+					finderCache.putResult(finderPath, finderArgs, count);
+				}
+			}
+			catch (Exception exception) {
+				throw processException(exception);
+			}
+			finally {
+				closeSession(session);
+			}
+		}
+
+		return count.intValue();
+	}
+
+	private static final String _FINDER_COLUMN_G_C_L_U_GROUPID_2 =
+		"friendlyURLEntryLocalization.groupId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_CLASSNAMEID_2 =
+		"friendlyURLEntryLocalization.classNameId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_LANGUAGEID_2 =
+		"friendlyURLEntryLocalization.languageId = ? AND ";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_LANGUAGEID_3 =
+		"(friendlyURLEntryLocalization.languageId IS NULL OR friendlyURLEntryLocalization.languageId = '') AND ";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_URLTITLE_2 =
+		"friendlyURLEntryLocalization.urlTitle = ?";
+
+	private static final String _FINDER_COLUMN_G_C_L_U_URLTITLE_3 =
+		"(friendlyURLEntryLocalization.urlTitle IS NULL OR friendlyURLEntryLocalization.urlTitle = '')";
+
 	public FriendlyURLEntryLocalizationPersistenceImpl() {
 		setModelClass(FriendlyURLEntryLocalization.class);
 
@@ -1954,10 +2008,11 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 			friendlyURLEntryLocalization);
 
 		finderCache.putResult(
-			_finderPathFetchByG_C_U,
+			_finderPathFetchByG_C_L_U,
 			new Object[] {
 				friendlyURLEntryLocalization.getGroupId(),
 				friendlyURLEntryLocalization.getClassNameId(),
+				friendlyURLEntryLocalization.getLanguageId(),
 				friendlyURLEntryLocalization.getUrlTitle()
 			},
 			friendlyURLEntryLocalization);
@@ -2070,12 +2125,13 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 		args = new Object[] {
 			friendlyURLEntryLocalizationModelImpl.getGroupId(),
 			friendlyURLEntryLocalizationModelImpl.getClassNameId(),
+			friendlyURLEntryLocalizationModelImpl.getLanguageId(),
 			friendlyURLEntryLocalizationModelImpl.getUrlTitle()
 		};
 
-		finderCache.putResult(_finderPathCountByG_C_U, args, Long.valueOf(1));
+		finderCache.putResult(_finderPathCountByG_C_L_U, args, Long.valueOf(1));
 		finderCache.putResult(
-			_finderPathFetchByG_C_U, args,
+			_finderPathFetchByG_C_L_U, args,
 			friendlyURLEntryLocalizationModelImpl);
 	}
 
@@ -2749,7 +2805,7 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 			new String[] {"friendlyURLEntryId", "languageId"});
 
 		_uniqueIndexColumnNames.add(
-			new String[] {"groupId", "classNameId", "urlTitle"});
+			new String[] {"groupId", "classNameId", "languageId", "urlTitle"});
 	}
 
 	/**
@@ -2801,22 +2857,6 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 			new String[] {Long.class.getName(), String.class.getName()},
 			new String[] {"friendlyURLEntryId", "languageId"}, false);
 
-		_finderPathFetchByG_C_U = new FinderPath(
-			FINDER_CLASS_NAME_ENTITY, "fetchByG_C_U",
-			new String[] {
-				Long.class.getName(), Long.class.getName(),
-				String.class.getName()
-			},
-			new String[] {"groupId", "classNameId", "urlTitle"}, true);
-
-		_finderPathCountByG_C_U = new FinderPath(
-			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_U",
-			new String[] {
-				Long.class.getName(), Long.class.getName(),
-				String.class.getName()
-			},
-			new String[] {"groupId", "classNameId", "urlTitle"}, false);
-
 		_finderPathWithPaginationFindByG_C_C_L = new FinderPath(
 			FINDER_CLASS_NAME_LIST_WITH_PAGINATION, "findByG_C_C_L",
 			new String[] {
@@ -2844,6 +2884,24 @@ public class FriendlyURLEntryLocalizationPersistenceImpl
 				Long.class.getName(), String.class.getName()
 			},
 			new String[] {"groupId", "classNameId", "classPK", "languageId"},
+			false);
+
+		_finderPathFetchByG_C_L_U = new FinderPath(
+			FINDER_CLASS_NAME_ENTITY, "fetchByG_C_L_U",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), String.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "languageId", "urlTitle"},
+			true);
+
+		_finderPathCountByG_C_L_U = new FinderPath(
+			FINDER_CLASS_NAME_LIST_WITHOUT_PAGINATION, "countByG_C_L_U",
+			new String[] {
+				Long.class.getName(), Long.class.getName(),
+				String.class.getName(), String.class.getName()
+			},
+			new String[] {"groupId", "classNameId", "languageId", "urlTitle"},
 			false);
 
 		_setFriendlyURLEntryLocalizationUtilPersistence(this);

--- a/modules/apps/friendly-url/friendly-url-service/src/main/resources/META-INF/sql/indexes.sql
+++ b/modules/apps/friendly-url/friendly-url-service/src/main/resources/META-INF/sql/indexes.sql
@@ -6,6 +6,6 @@ create unique index IX_D51F1A48 on FriendlyURLEntry (uuid_[$COLUMN_LENGTH:75$], 
 create index IX_4F41A5C8 on FriendlyURLEntryLocalization (friendlyURLEntryId, ctCollectionId);
 create unique index IX_BBF3E90F on FriendlyURLEntryLocalization (friendlyURLEntryId, languageId[$COLUMN_LENGTH:75$], ctCollectionId);
 create index IX_40A51197 on FriendlyURLEntryLocalization (groupId, classNameId, classPK, languageId[$COLUMN_LENGTH:75$], ctCollectionId);
-create unique index IX_C753170C on FriendlyURLEntryLocalization (groupId, classNameId, urlTitle[$COLUMN_LENGTH:255$], ctCollectionId);
+create unique index IX_29720B13 on FriendlyURLEntryLocalization (groupId, classNameId, languageId[$COLUMN_LENGTH:75$], urlTitle[$COLUMN_LENGTH:255$], ctCollectionId);
 
 create unique index IX_5BE324B9 on FriendlyURLEntryMapping (classNameId, classPK, ctCollectionId);

--- a/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
+++ b/modules/apps/friendly-url/friendly-url-test/src/testIntegration/java/com/liferay/friendly/url/service/persistence/test/FriendlyURLEntryLocalizationPersistenceTest.java
@@ -208,16 +208,6 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 	}
 
 	@Test
-	public void testCountByG_C_U() throws Exception {
-		_persistence.countByG_C_U(
-			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "");
-
-		_persistence.countByG_C_U(0L, 0L, "null");
-
-		_persistence.countByG_C_U(0L, 0L, (String)null);
-	}
-
-	@Test
 	public void testCountByG_C_C_L() throws Exception {
 		_persistence.countByG_C_C_L(
 			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(),
@@ -226,6 +216,16 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 		_persistence.countByG_C_C_L(0L, 0L, 0L, "null");
 
 		_persistence.countByG_C_C_L(0L, 0L, 0L, (String)null);
+	}
+
+	@Test
+	public void testCountByG_C_L_U() throws Exception {
+		_persistence.countByG_C_L_U(
+			RandomTestUtil.nextLong(), RandomTestUtil.nextLong(), "", "");
+
+		_persistence.countByG_C_L_U(0L, 0L, "null", "null");
+
+		_persistence.countByG_C_L_U(0L, 0L, (String)null, (String)null);
 	}
 
 	@Test
@@ -564,6 +564,11 @@ public class FriendlyURLEntryLocalizationPersistenceTest {
 			ReflectionTestUtil.<Long>invoke(
 				friendlyURLEntryLocalization, "getColumnOriginalValue",
 				new Class<?>[] {String.class}, "classNameId"));
+		Assert.assertEquals(
+			friendlyURLEntryLocalization.getLanguageId(),
+			ReflectionTestUtil.invoke(
+				friendlyURLEntryLocalization, "getColumnOriginalValue",
+				new Class<?>[] {String.class}, "languageId"));
 		Assert.assertEquals(
 			friendlyURLEntryLocalization.getUrlTitle(),
 			ReflectionTestUtil.invoke(

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutFriendlyURLEntryValidatorImpl.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutFriendlyURLEntryValidatorImpl.java
@@ -37,14 +37,15 @@ public class LayoutFriendlyURLEntryValidatorImpl
 
 	@Override
 	public void validateFriendlyURLEntry(
-			long groupId, boolean privateLayout, long classPK, String urlTitle)
+		long groupId, boolean privateLayout, long classPK, String urlTitle,
+		String languageId)
 		throws PortalException {
 
 		try {
 			_friendlyURLEntryLocalService.validate(
 				groupId,
 				_layoutFriendlyURLEntryHelper.getClassNameId(privateLayout),
-				classPK, urlTitle);
+				classPK,languageId, urlTitle);
 		}
 		catch (DuplicateFriendlyURLEntryException
 					duplicateFriendlyURLEntryException) {

--- a/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutFriendlyURLEntryValidatorImpl.java
+++ b/modules/apps/layout/layout-service/src/main/java/com/liferay/layout/internal/service/LayoutFriendlyURLEntryValidatorImpl.java
@@ -37,15 +37,15 @@ public class LayoutFriendlyURLEntryValidatorImpl
 
 	@Override
 	public void validateFriendlyURLEntry(
-		long groupId, boolean privateLayout, long classPK, String urlTitle,
-		String languageId)
+			long groupId, boolean privateLayout, long classPK, String urlTitle,
+			String languageId)
 		throws PortalException {
 
 		try {
 			_friendlyURLEntryLocalService.validate(
 				groupId,
 				_layoutFriendlyURLEntryHelper.getClassNameId(privateLayout),
-				classPK,languageId, urlTitle);
+				classPK, languageId, urlTitle);
 		}
 		catch (DuplicateFriendlyURLEntryException
 					duplicateFriendlyURLEntryException) {

--- a/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/LayoutFriendlyURLTest.java
+++ b/modules/apps/layout/layout-test/src/testIntegration/java/com/liferay/layout/test/LayoutFriendlyURLTest.java
@@ -427,7 +427,7 @@ public class LayoutFriendlyURLTest {
 		}
 	}
 
-	@Test(expected = LayoutFriendlyURLsException.class)
+	@Test
 	public void testSameFriendlyURLDifferentLocalePrivateLayout()
 		throws Exception {
 
@@ -440,7 +440,7 @@ public class LayoutFriendlyURLTest {
 			).build());
 	}
 
-	@Test(expected = LayoutFriendlyURLsException.class)
+	@Test
 	public void testSameFriendlyURLDifferentLocalePublicLayout()
 		throws Exception {
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -66,12 +66,10 @@ import com.liferay.portal.util.LayoutTypeControllerTracker;
 import com.liferay.sites.kernel.util.SitesUtil;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -401,8 +399,7 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 			Layout layout = layoutPersistence.findByPrimaryKey(
 				layoutFriendlyURL.getPlid());
 
-			if ((layout.getLayoutId() != layoutId)) {
-
+			if (layout.getLayoutId() != layoutId) {
 				LayoutFriendlyURLException layoutFriendlyURLException =
 					new LayoutFriendlyURLException(
 						LayoutFriendlyURLException.DUPLICATE);

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -401,9 +401,7 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 			Layout layout = layoutPersistence.findByPrimaryKey(
 				layoutFriendlyURL.getPlid());
 
-			if ((layout.getLayoutId() != layoutId) ||
-				(Validator.isNotNull(languageId) &&
-				 !languageId.equals(layoutFriendlyURL.getLanguageId()))) {
+			if ((layout.getLayoutId() != layoutId)) {
 
 				LayoutFriendlyURLException layoutFriendlyURLException =
 					new LayoutFriendlyURLException(
@@ -536,17 +534,6 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 		throws PortalException {
 
 		LayoutFriendlyURLsException layoutFriendlyURLsException = null;
-
-		Set<String> friendlyURLs = new HashSet<>(friendlyURLMap.values());
-
-		if (friendlyURLs.size() != friendlyURLMap.size()) {
-			LayoutFriendlyURLException layoutFriendlyURLException =
-				new LayoutFriendlyURLException(
-					LayoutFriendlyURLException.DUPLICATE);
-
-			layoutFriendlyURLsException = new LayoutFriendlyURLsException(
-				layoutFriendlyURLException);
-		}
 
 		for (Map.Entry<Locale, String> entry : friendlyURLMap.entrySet()) {
 			try {

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -118,7 +118,8 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 					}
 
 					_layoutFriendlyURLEntryValidator.validateFriendlyURLEntry(
-						groupId, privateLayout, classPK, friendlyURL, languageId);
+						groupId, privateLayout, classPK, friendlyURL,
+						languageId);
 				}
 
 				break;

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceHelper.java
@@ -118,7 +118,7 @@ public class LayoutLocalServiceHelper implements IdentifiableOSGiService {
 					}
 
 					_layoutFriendlyURLEntryValidator.validateFriendlyURLEntry(
-						groupId, privateLayout, classPK, friendlyURL);
+						groupId, privateLayout, classPK, friendlyURL, languageId);
 				}
 
 				break;

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutFriendlyURLEntryValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutFriendlyURLEntryValidator.java
@@ -23,7 +23,7 @@ import com.liferay.portal.kernel.exception.PortalException;
 public interface LayoutFriendlyURLEntryValidator {
 
 	public void validateFriendlyURLEntry(
-			long groupId, boolean privateLayout, long classPK, String urlTitle)
+			long groupId, boolean privateLayout, long classPK, String urlTitle, String languageId)
 		throws PortalException;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/LayoutFriendlyURLEntryValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/LayoutFriendlyURLEntryValidator.java
@@ -23,7 +23,8 @@ import com.liferay.portal.kernel.exception.PortalException;
 public interface LayoutFriendlyURLEntryValidator {
 
 	public void validateFriendlyURLEntry(
-			long groupId, boolean privateLayout, long classPK, String urlTitle, String languageId)
+			long groupId, boolean privateLayout, long classPK, String urlTitle,
+			String languageId)
 		throws PortalException;
 
 }

--- a/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/service/packageinfo
@@ -1,1 +1,1 @@
-version 17.0.0
+version 18.0.0


### PR DESCRIPTION
- LPS-166653 create new finder and delete previous without languageId
- LPS-166653 buildService
- LPS-166653 allow repeating same friendlyurl for different locale in same layout
- LPS-166653 SF
- LPS-166653 add languageId to validator
- LPS-166653 apply usages of validator
- LPS-166653 check if language is null and use default as fallback
- LPS-166653 these tests doesn't have to throw an exception
- LPS-166653 SF
