### PR TITLE
LPS 164298 part2

### DIFF
--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -16,6 +16,7 @@ package com.liferay.portal.util;
 
 import com.liferay.counter.kernel.service.CounterLocalServiceUtil;
 import com.liferay.document.library.kernel.exception.ImageSizeException;
+import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.model.DLFolder;
 import com.liferay.expando.kernel.exception.ValueDataException;
@@ -44,7 +45,6 @@ import com.liferay.portal.kernel.dao.orm.QueryUtil;
 import com.liferay.portal.kernel.encryptor.EncryptorUtil;
 import com.liferay.portal.kernel.exception.ImageTypeException;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
-import com.liferay.portal.kernel.exception.NoSuchImageException;
 import com.liferay.portal.kernel.exception.NoSuchLayoutException;
 import com.liferay.portal.kernel.exception.NoSuchUserException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -6562,7 +6562,7 @@ public class PortalImpl implements Portal {
 					exception.getMessage()));
 		}
 
-		if (exception instanceof NoSuchImageException) {
+		if (exception instanceof NoSuchFileEntryException) {
 			if (_webServerServletLog.isWarnEnabled()) {
 				_webServerServletLog.warn(exception, exception);
 			}
@@ -6667,7 +6667,11 @@ public class PortalImpl implements Portal {
 
 			httpServletResponse.setStatus(status);
 
-			SessionErrors.add(httpSession, exception.getClass(), exception);
+			if ((exception != null) &&
+				!(exception instanceof NoSuchFileEntryException)) {
+
+				SessionErrors.add(httpSession, exception.getClass(), exception);
+			}
 
 			ServletContext servletContext = httpSession.getServletContext();
 

--- a/portal-impl/src/com/liferay/portal/util/PortalImpl.java
+++ b/portal-impl/src/com/liferay/portal/util/PortalImpl.java
@@ -6667,9 +6667,7 @@ public class PortalImpl implements Portal {
 
 			httpServletResponse.setStatus(status);
 
-			if ((exception != null) &&
-				!(exception instanceof NoSuchFileEntryException)) {
-
+			if (!(exception instanceof NoSuchFileEntryException)) {
 				SessionErrors.add(httpSession, exception.getClass(), exception);
 			}
 

--- a/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/sites/friendlyurl/FriendlyURL.testcase
+++ b/portal-web/test/functional/com/liferay/portalweb/tests/coreinfrastructure/administration/sites/friendlyurl/FriendlyURL.testcase
@@ -42,6 +42,73 @@ definition {
 		AssertConsoleTextPresent(value1 = "NoSuchVirtualHostException");
 	}
 
+	@description = "Verify no error message is shown when navigating from a page with a missing image to another page."
+	@priority = "3"
+	test NavigateFromPageWithMissingImageWithoutError {
+		task ("Given an image is saved in Documents & Media") {
+			JSONDocument.addFileWithUploadedFile(
+				dmDocumentTitle = "Document_1.jpg",
+				groupName = "Test Site Name",
+				mimeType = "image/jpeg",
+				sourceFileName = "Document_1.jpg");
+		}
+
+		task ("And given a basic web content that includes the image as content") {
+			WebContentNavigator.openWebContentAdmin(siteURLKey = "test-site-name");
+
+			WebContentNavigator.gotoAddCP();
+
+			WebContent.addCP(
+				embedImage = "true",
+				imageFileName = "Document_1.jpg",
+				siteName = "Test Site Name",
+				webContentTitle = "WC WebContent Title");
+
+			PortletEntry.publish();
+		}
+
+		task ("And given a page with a Web Content Display widget configured to show the web content") {
+			JSONLayout.addPublicLayout(
+				groupName = "Test Site Name",
+				layoutName = "Web Content Page");
+
+			JSONLayout.addWidgetToPublicLayout(
+				groupName = "Test Site Name",
+				layoutName = "Web Content Page",
+				widgetName = "Web Content Display");
+
+			Navigator.gotoSitePage(
+				pageName = "Web Content Page",
+				siteName = "Test Site Name");
+
+			WebContentDisplayPortlet.selectWebContent(webContentTitle = "WC WebContent Title");
+		}
+
+		task ("And given the user removes the image from Documents & Media") {
+			DMNavigator.openDocumentsAndMediaAdmin(siteURLKey = "test-site-name");
+
+			DMDocument.deleteCP(dmDocumentTitle = "Document_1.jpg");
+		}
+
+		task ("When the user goes to the web content page with the now missing image") {
+			Navigator.gotoSitePage(
+				pageName = "Web Content Page",
+				siteName = "Test Site Name");
+		}
+
+		task ("And navigates to a different page") {
+			User.openUsersAdmin();
+		}
+
+		task ("Then the page should open without error") {
+			if (IsElementPresent(locator1 = "Message#ERROR")) {
+				fail("Error message is present");
+			}
+
+			LexiconEntry.viewEntryName(rowEntry = "Test Test");
+		}
+	}
+
 	@description = "Verify navigating to the URL of an uncreated portlet does not throw errors."
 	@priority = "3"
 	test NavigatingToURLOfUncreatedPortletDoesNotThrowError {


### PR DESCRIPTION
- LPS-164298 changing catch to NoSuchFileEntryException as NoSuchImageException is not being thrown, avoid sending default error when NSFE is thrown as 404 is being sent already
- LPS-164298 remove null checking as it's done by instanceof operation
- LPS-164298 Add NavigateFromPageWithMissingImageWithoutError test
