### PR TITLE
LPD-28294

### DIFF
--- a/modules/dxp/apps/saml/saml-web/build.gradle
+++ b/modules/dxp/apps/saml/saml-web/build.gradle
@@ -23,4 +23,6 @@ dependencies {
 	compileOnly project(":dxp:apps:saml:saml-api")
 	compileOnly project(":dxp:apps:saml:saml-opensaml-integration")
 	compileOnly project(":dxp:apps:saml:saml-persistence-api")
+
+	testImplementation group: "com.liferay.portal", name: "com.liferay.portal.impl", version: "default"
 }

--- a/modules/dxp/apps/saml/saml-web/build.gradle
+++ b/modules/dxp/apps/saml/saml-web/build.gradle
@@ -11,6 +11,7 @@ dependencies {
 	compileOnly project(":apps:frontend-taglib:frontend-taglib")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-clay")
 	compileOnly project(":apps:frontend-taglib:frontend-taglib-form-navigator")
+	compileOnly project(":apps:layout:layout-seo-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":apps:static:portal:portal-upgrade-api")

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -5,21 +5,25 @@
 
 package com.liferay.saml.web.internal.struts;
 
-import com.liferay.petra.string.StringPool;
+import com.liferay.layout.seo.kernel.LayoutSEOLinkManager;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.struts.StrutsAction;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.util.WebKeys;
 import com.liferay.saml.constants.SamlWebKeys;
 import com.liferay.saml.persistence.model.SamlSpIdpConnection;
 import com.liferay.saml.persistence.service.SamlSpIdpConnectionLocalService;
@@ -110,9 +114,22 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 					"redirecting-to-your-identity-provider"));
 		}
 		else if (samlSpIdpConnections.size() == 1) {
+			Layout layout = (Layout)httpServletRequest.getAttribute(
+				WebKeys.LAYOUT);
+
+			Company company = _portal.getCompany(httpServletRequest);
+
+			ThemeDisplay themeDisplay =
+				(ThemeDisplay)httpServletRequest.getAttribute(
+					WebKeys.THEME_DISPLAY);
+
+			String title = _layoutSEOLinkManager.getFullPageTitle(
+				layout, null, null, null, null, company.getName(),
+				themeDisplay.getLocale());
+
 			JspUtil.dispatch(
 				httpServletRequest, httpServletResponse,
-				"/portal/saml/select_idp.jsp", StringPool.BLANK, true);
+				"/portal/saml/select_idp.jsp", title, true);
 
 			return null;
 		}
@@ -170,6 +187,9 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 
 	@Reference
 	private Language _language;
+
+	@Reference
+	private LayoutSEOLinkManager _layoutSEOLinkManager;
 
 	@Reference
 	private Portal _portal;

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -97,6 +97,10 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 		boolean samlIdpRedirectMessageEnabled = GetterUtil.getBoolean(
 			_props.get("saml.idp.redirect.message.enabled"), true);
 
+		httpServletRequest.setAttribute(
+			SamlWebKeys.SAML_SSO_LOGIN_CONTEXT,
+			_toJSONObject(samlSpIdpConnections));
+
 		if (samlIdpRedirectMessageEnabled) {
 			httpServletRequest.setAttribute(
 				SamlWebKeys.SAML_IDP_REDIRECT_MESSAGE,
@@ -104,10 +108,13 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 					httpServletRequest,
 					"redirecting-to-your-identity-provider"));
 		}
+		else if (samlSpIdpConnections.size() == 1) {
+			JspUtil.dispatch(
+				httpServletRequest, httpServletResponse,
+				"/portal/saml/select_idp.jsp", "", true);
 
-		httpServletRequest.setAttribute(
-			SamlWebKeys.SAML_SSO_LOGIN_CONTEXT,
-			_toJSONObject(samlSpIdpConnections));
+			return null;
+		}
 
 		JspUtil.dispatch(
 			httpServletRequest, httpServletResponse,

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -12,7 +12,6 @@ import com.liferay.portal.kernel.json.JSONObject;
 import com.liferay.portal.kernel.json.JSONUtil;
 import com.liferay.portal.kernel.language.Language;
 import com.liferay.portal.kernel.model.Company;
-import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.module.service.Snapshot;
 import com.liferay.portal.kernel.security.auth.AuthTokenUtil;
 import com.liferay.portal.kernel.struts.StrutsAction;
@@ -114,18 +113,15 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 					"redirecting-to-your-identity-provider"));
 		}
 		else if (samlSpIdpConnections.size() == 1) {
-			Layout layout = (Layout)httpServletRequest.getAttribute(
-				WebKeys.LAYOUT);
-
-			Company company = _portal.getCompany(httpServletRequest);
-
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)httpServletRequest.getAttribute(
 					WebKeys.THEME_DISPLAY);
 
+			Company company = _portal.getCompany(httpServletRequest);
+
 			String title = _layoutSEOLinkManager.getFullPageTitle(
-				layout, null, null, null, null, company.getName(),
-				themeDisplay.getLocale());
+				themeDisplay.getLayout(), null, null, null, null,
+				company.getName(), themeDisplay.getLocale());
 
 			JspUtil.dispatch(
 				httpServletRequest, httpServletResponse,

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -5,6 +5,7 @@
 
 package com.liferay.saml.web.internal.struts;
 
+import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactory;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -111,7 +112,7 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 		else if (samlSpIdpConnections.size() == 1) {
 			JspUtil.dispatch(
 				httpServletRequest, httpServletResponse,
-				"/portal/saml/select_idp.jsp", "", true);
+				"/portal/saml/select_idp.jsp", StringPool.BLANK, true);
 
 			return null;
 		}

--- a/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
+++ b/modules/dxp/apps/saml/saml-web/src/main/java/com/liferay/saml/web/internal/struts/SamlLoginAction.java
@@ -63,13 +63,13 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 		String entityId = ParamUtil.getString(
 			httpServletRequest, "idpEntityId");
 
-		long companyId = _portal.getCompanyId(httpServletRequest);
+		Company company = _portal.getCompany(httpServletRequest);
 
 		if (Validator.isNotNull(entityId)) {
 			httpServletRequest.setAttribute(
 				SamlWebKeys.SAML_SP_IDP_CONNECTION,
 				_samlSpIdpConnectionLocalService.getSamlSpIdpConnection(
-					companyId, entityId));
+					company.getCompanyId(), entityId));
 
 			if (GetterUtil.getBoolean(
 					ParamUtil.getBoolean(httpServletRequest, "forceAuthn"))) {
@@ -85,7 +85,8 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 		}
 
 		List<SamlSpIdpConnection> samlSpIdpConnections = ListUtil.filter(
-			_samlSpIdpConnectionLocalService.getSamlSpIdpConnections(companyId),
+			_samlSpIdpConnectionLocalService.getSamlSpIdpConnections(
+				company.getCompanyId()),
 			samlSpIdpConnection -> isEnabled(
 				samlSpIdpConnection, httpServletRequest));
 
@@ -116,8 +117,6 @@ public class SamlLoginAction extends BaseSamlStrutsAction {
 			ThemeDisplay themeDisplay =
 				(ThemeDisplay)httpServletRequest.getAttribute(
 					WebKeys.THEME_DISPLAY);
-
-			Company company = _portal.getCompany(httpServletRequest);
 
 			String title = _layoutSEOLinkManager.getFullPageTitle(
 				themeDisplay.getLayout(), null, null, null, null,

--- a/modules/dxp/apps/saml/saml-web/src/test/java/com/liferay/saml/web/internal/struts/SamlLoginActionTest.java
+++ b/modules/dxp/apps/saml/saml-web/src/test/java/com/liferay/saml/web/internal/struts/SamlLoginActionTest.java
@@ -149,9 +149,13 @@ public class SamlLoginActionTest {
 			htmlTitle
 		);
 
-		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, layout);
-
 		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getLayout()
+		).thenReturn(
+			layout
+		);
 
 		Mockito.when(
 			themeDisplay.getLocale()

--- a/modules/dxp/apps/saml/saml-web/src/test/java/com/liferay/saml/web/internal/struts/SamlLoginActionTest.java
+++ b/modules/dxp/apps/saml/saml-web/src/test/java/com/liferay/saml/web/internal/struts/SamlLoginActionTest.java
@@ -1,0 +1,266 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2024 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.saml.web.internal.struts;
+
+import com.liferay.layout.seo.kernel.LayoutSEOLink;
+import com.liferay.layout.seo.kernel.LayoutSEOLinkManager;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONFactoryUtil;
+import com.liferay.portal.kernel.model.Company;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ListMergeable;
+import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.Props;
+import com.liferay.portal.kernel.util.StringUtil;
+import com.liferay.portal.kernel.util.WebKeys;
+import com.liferay.portal.struts.Definition;
+import com.liferay.portal.struts.TilesUtil;
+import com.liferay.portal.test.rule.LiferayUnitTestRule;
+import com.liferay.saml.persistence.model.SamlSpIdpConnection;
+import com.liferay.saml.persistence.service.SamlSpIdpConnectionLocalService;
+import com.liferay.saml.runtime.configuration.SamlProviderConfigurationHelper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Predicate;
+
+import javax.servlet.http.HttpServletRequest;
+
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+/**
+ * @author Pedro Victor Silvestre
+ */
+public class SamlLoginActionTest {
+
+	@ClassRule
+	@Rule
+	public static final LiferayUnitTestRule liferayUnitTestRule =
+		LiferayUnitTestRule.INSTANCE;
+
+	@Test
+	public void testPageTitleIsSameWhenRedirectMessageIsDisabled()
+		throws Exception {
+
+		SamlLoginAction samlLoginAction = new SamlLoginAction();
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_samlProviderConfigurationHelper",
+			_createSamlProviderConfigurationHelper());
+
+		Props props = Mockito.mock(Props.class);
+
+		Mockito.when(
+			props.get("saml.idp.redirect.message.enabled")
+		).thenReturn(
+			"false"
+		);
+
+		ReflectionTestUtil.setFieldValue(samlLoginAction, "_props", props);
+
+		String companyName = RandomTestUtil.randomString();
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_portal", _createPortal(companyName));
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_samlSpIdpConnectionLocalService",
+			_createSamlSpIdpConnectionLocalService());
+
+		JSONFactory jsonFactory = Mockito.mock(JSONFactory.class);
+
+		Mockito.when(
+			jsonFactory.createJSONArray()
+		).thenReturn(
+			JSONFactoryUtil.createJSONArray()
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_jsonFactory", jsonFactory);
+
+		LayoutSEOLinkManager layoutSEOLinkManager = new LayoutSEOLinkManager() {
+
+			@Override
+			public LayoutSEOLink getCanonicalLayoutSEOLink(
+					Layout layout, Locale locale, String canonicalURL,
+					ThemeDisplay themeDisplay)
+				throws PortalException {
+
+				return null;
+			}
+
+			@Override
+			public String getFullPageTitle(
+				Layout layout, String portletId, String tilesTitle,
+				ListMergeable<String> titleListMergeable,
+				ListMergeable<String> subtitleListMergeable, String companyName,
+				Locale locale) {
+
+				return StringUtil.merge(
+					new String[] {layout.getHTMLTitle(locale), companyName},
+					_SEPARATOR);
+			}
+
+			@Override
+			public List<LayoutSEOLink> getLocalizedLayoutSEOLinks(
+					Layout layout, Locale locale, String canonicalURL,
+					Set<Locale> availableLocales)
+				throws PortalException {
+
+				return null;
+			}
+
+		};
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_layoutSEOLinkManager", layoutSEOLinkManager);
+
+		MockHttpServletRequest mockHttpServletRequest =
+			new MockHttpServletRequest();
+
+		String htmlTitle = RandomTestUtil.randomString();
+
+		Layout layout = Mockito.mock(Layout.class);
+
+		Mockito.when(
+			layout.getHTMLTitle(Mockito.any(Locale.class))
+		).thenReturn(
+			htmlTitle
+		);
+
+		mockHttpServletRequest.setAttribute(WebKeys.LAYOUT, layout);
+
+		ThemeDisplay themeDisplay = Mockito.mock(ThemeDisplay.class);
+
+		Mockito.when(
+			themeDisplay.getLocale()
+		).thenReturn(
+			LocaleUtil.ENGLISH
+		);
+
+		mockHttpServletRequest.setAttribute(
+			WebKeys.THEME_DISPLAY, themeDisplay);
+
+		samlLoginAction.execute(
+			mockHttpServletRequest, new MockHttpServletResponse());
+
+		Definition definition = (Definition)mockHttpServletRequest.getAttribute(
+			TilesUtil.DEFINITION);
+
+		Map<String, String> definitionAttributes = definition.getAttributes();
+
+		Assert.assertEquals(
+			StringUtil.merge(new String[] {htmlTitle, companyName}, _SEPARATOR),
+			definitionAttributes.get("title"));
+	}
+
+	private Portal _createPortal(String companyName) throws Exception {
+		Portal portal = Mockito.mock(Portal.class);
+
+		Mockito.when(
+			portal.getCompanyId(Mockito.any(HttpServletRequest.class))
+		).thenReturn(
+			RandomTestUtil.randomLong()
+		);
+
+		Company company = Mockito.mock(Company.class);
+
+		Mockito.when(
+			company.getName()
+		).thenReturn(
+			companyName
+		);
+
+		Mockito.when(
+			portal.getCompany(Mockito.any(HttpServletRequest.class))
+		).thenReturn(
+			company
+		);
+
+		return portal;
+	}
+
+	private SamlProviderConfigurationHelper
+		_createSamlProviderConfigurationHelper() {
+
+		SamlProviderConfigurationHelper samlProviderConfigurationHelper =
+			Mockito.mock(SamlProviderConfigurationHelper.class);
+
+		Mockito.when(
+			samlProviderConfigurationHelper.isRoleSp()
+		).thenReturn(
+			true
+		);
+
+		Mockito.when(
+			samlProviderConfigurationHelper.isEnabled()
+		).thenReturn(
+			true
+		);
+
+		return samlProviderConfigurationHelper;
+	}
+
+	private SamlSpIdpConnectionLocalService
+		_createSamlSpIdpConnectionLocalService() {
+
+		SamlSpIdpConnectionLocalService samlSpIdpConnectionLocalService =
+			Mockito.mock(SamlSpIdpConnectionLocalService.class);
+
+		List<SamlSpIdpConnection> samlSpIdpConnections = new ArrayList<>();
+
+		SamlSpIdpConnection samlSpIdpConnection = Mockito.mock(
+			SamlSpIdpConnection.class);
+
+		samlSpIdpConnections.add(samlSpIdpConnection);
+
+		Mockito.when(
+			samlSpIdpConnectionLocalService.getSamlSpIdpConnections(
+				Mockito.anyLong())
+		).thenReturn(
+			samlSpIdpConnections
+		);
+
+		Mockito.when(
+			samlSpIdpConnection.isEnabled()
+		).thenReturn(
+			true
+		);
+
+		_listUtilMockedStatic.when(
+			() -> ListUtil.filter(
+				Mockito.anyList(), Mockito.any(Predicate.class))
+		).thenReturn(
+			samlSpIdpConnections
+		);
+
+		return samlSpIdpConnectionLocalService;
+	}
+
+	private static final String _SEPARATOR = " - ";
+
+	private static final MockedStatic<ListUtil> _listUtilMockedStatic =
+		Mockito.mockStatic(ListUtil.class);
+
+}

--- a/modules/dxp/apps/saml/saml-web/src/test/java/com/liferay/saml/web/internal/struts/SamlLoginActionTest.java
+++ b/modules/dxp/apps/saml/saml-web/src/test/java/com/liferay/saml/web/internal/struts/SamlLoginActionTest.java
@@ -63,43 +63,30 @@ public class SamlLoginActionTest {
 	public void testPageTitleIsSameWhenRedirectMessageIsDisabled()
 		throws Exception {
 
-		SamlLoginAction samlLoginAction = new SamlLoginAction();
-
-		ReflectionTestUtil.setFieldValue(
-			samlLoginAction, "_samlProviderConfigurationHelper",
-			_createSamlProviderConfigurationHelper());
-
-		Props props = Mockito.mock(Props.class);
-
-		Mockito.when(
-			props.get("saml.idp.redirect.message.enabled")
-		).thenReturn(
-			"false"
-		);
-
-		ReflectionTestUtil.setFieldValue(samlLoginAction, "_props", props);
-
 		String companyName = RandomTestUtil.randomString();
 
-		ReflectionTestUtil.setFieldValue(
-			samlLoginAction, "_portal", _createPortal(companyName));
+		SamlLoginAction samlLoginAction = _setupSamlLoginAction(companyName);
 
-		ReflectionTestUtil.setFieldValue(
-			samlLoginAction, "_samlSpIdpConnectionLocalService",
-			_createSamlSpIdpConnectionLocalService());
+		String htmlTitle = RandomTestUtil.randomString();
 
-		JSONFactory jsonFactory = Mockito.mock(JSONFactory.class);
+		MockHttpServletRequest mockHttpServletRequest =
+			_getMockHttpServletRequest(htmlTitle);
 
-		Mockito.when(
-			jsonFactory.createJSONArray()
-		).thenReturn(
-			JSONFactoryUtil.createJSONArray()
-		);
+		samlLoginAction.execute(
+			mockHttpServletRequest, new MockHttpServletResponse());
 
-		ReflectionTestUtil.setFieldValue(
-			samlLoginAction, "_jsonFactory", jsonFactory);
+		Definition definition = (Definition)mockHttpServletRequest.getAttribute(
+			TilesUtil.DEFINITION);
 
-		LayoutSEOLinkManager layoutSEOLinkManager = new LayoutSEOLinkManager() {
+		Map<String, String> definitionAttributes = definition.getAttributes();
+
+		Assert.assertEquals(
+			StringUtil.merge(new String[] {htmlTitle, companyName}, _SEPARATOR),
+			definitionAttributes.get("title"));
+	}
+
+	private LayoutSEOLinkManager _getLayoutSEOLinkManager() {
+		return new LayoutSEOLinkManager() {
 
 			@Override
 			public LayoutSEOLink getCanonicalLayoutSEOLink(
@@ -132,14 +119,13 @@ public class SamlLoginActionTest {
 			}
 
 		};
+	}
 
-		ReflectionTestUtil.setFieldValue(
-			samlLoginAction, "_layoutSEOLinkManager", layoutSEOLinkManager);
+	private MockHttpServletRequest _getMockHttpServletRequest(
+		String htmlTitle) {
 
 		MockHttpServletRequest mockHttpServletRequest =
 			new MockHttpServletRequest();
-
-		String htmlTitle = RandomTestUtil.randomString();
 
 		Layout layout = Mockito.mock(Layout.class);
 
@@ -166,35 +152,25 @@ public class SamlLoginActionTest {
 		mockHttpServletRequest.setAttribute(
 			WebKeys.THEME_DISPLAY, themeDisplay);
 
-		samlLoginAction.execute(
-			mockHttpServletRequest, new MockHttpServletResponse());
-
-		Definition definition = (Definition)mockHttpServletRequest.getAttribute(
-			TilesUtil.DEFINITION);
-
-		Map<String, String> definitionAttributes = definition.getAttributes();
-
-		Assert.assertEquals(
-			StringUtil.merge(new String[] {htmlTitle, companyName}, _SEPARATOR),
-			definitionAttributes.get("title"));
+		return mockHttpServletRequest;
 	}
 
-	private Portal _createPortal(String companyName) throws Exception {
-		Portal portal = Mockito.mock(Portal.class);
+	private Portal _setupPortal(String companyName) throws Exception {
+		Company company = Mockito.mock(Company.class);
 
 		Mockito.when(
-			portal.getCompanyId(Mockito.any(HttpServletRequest.class))
+			company.getCompanyId()
 		).thenReturn(
 			RandomTestUtil.randomLong()
 		);
-
-		Company company = Mockito.mock(Company.class);
 
 		Mockito.when(
 			company.getName()
 		).thenReturn(
 			companyName
 		);
+
+		Portal portal = Mockito.mock(Portal.class);
 
 		Mockito.when(
 			portal.getCompany(Mockito.any(HttpServletRequest.class))
@@ -205,8 +181,52 @@ public class SamlLoginActionTest {
 		return portal;
 	}
 
+	private SamlLoginAction _setupSamlLoginAction(String companyName)
+		throws Exception {
+
+		SamlLoginAction samlLoginAction = new SamlLoginAction();
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_samlProviderConfigurationHelper",
+			_setupSamlProviderConfigurationHelper());
+
+		Props props = Mockito.mock(Props.class);
+
+		Mockito.when(
+			props.get("saml.idp.redirect.message.enabled")
+		).thenReturn(
+			"false"
+		);
+
+		ReflectionTestUtil.setFieldValue(samlLoginAction, "_props", props);
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_portal", _setupPortal(companyName));
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_samlSpIdpConnectionLocalService",
+			_setupSamlSpIdpConnectionLocalService());
+
+		JSONFactory jsonFactory = Mockito.mock(JSONFactory.class);
+
+		Mockito.when(
+			jsonFactory.createJSONArray()
+		).thenReturn(
+			JSONFactoryUtil.createJSONArray()
+		);
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_jsonFactory", jsonFactory);
+
+		ReflectionTestUtil.setFieldValue(
+			samlLoginAction, "_layoutSEOLinkManager",
+			_getLayoutSEOLinkManager());
+
+		return samlLoginAction;
+	}
+
 	private SamlProviderConfigurationHelper
-		_createSamlProviderConfigurationHelper() {
+		_setupSamlProviderConfigurationHelper() {
 
 		SamlProviderConfigurationHelper samlProviderConfigurationHelper =
 			Mockito.mock(SamlProviderConfigurationHelper.class);
@@ -227,7 +247,7 @@ public class SamlLoginActionTest {
 	}
 
 	private SamlSpIdpConnectionLocalService
-		_createSamlSpIdpConnectionLocalService() {
+		_setupSamlSpIdpConnectionLocalService() {
 
 		SamlSpIdpConnectionLocalService samlSpIdpConnectionLocalService =
 			Mockito.mock(SamlSpIdpConnectionLocalService.class);


### PR DESCRIPTION
- LPD-28294 Remove the title from the select idp portlet when redirect message is disabled and there is only one idp connected
- LPD-28294 SF
- LPD-28294 Pass full page title in dispatch instead so title remains the same
- LPD-28294 Add unit test for checking if page title is correct
- LPD-28294 SF get Layout from ThemeDisplay
- LPD-28294 SF get company object and then use it across the method
- LPD-28294 SF
