### PR TITLE
LPD-93274 Expose the FIPS provider status as a reusable result

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSModeValidator.java
@@ -5,6 +5,7 @@
 
 package com.liferay.portal.kernel.security.fips;
 
+import com.liferay.petra.function.transform.TransformUtil;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.StringBundler;
 import com.liferay.portal.kernel.security.pwd.PasswordEncryptor;
@@ -26,24 +27,74 @@ import java.util.Objects;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import javax.net.ssl.SSLContext;
+
 /**
  * @author Caio Farias
+ * @author Jorge García Jiménez
  */
 public class FIPSModeValidator {
 
-	public static void validate() {
+	public static FIPSProviderStatus getStatus() {
 		Provider[] providers = Security.getProviders();
 
-		_validateFIPSProvider(providers);
-		_validateProviders(providers);
+		List<String> providerOrder = TransformUtil.transformToList(
+			providers, Provider::getName);
+
+		String providerName = null;
+		String providerVersion = null;
+
+		if (ArrayUtil.isNotEmpty(providers)) {
+			Provider provider = providers[0];
+
+			providerName = provider.getName();
+			providerVersion = provider.getVersionStr();
+		}
+
+		String failedCheck = _validateFIPSProvider(providers);
+
+		boolean approvedMode = false;
+
+		if (failedCheck == null) {
+			approvedMode = true;
+		}
+
+		if (approvedMode) {
+			failedCheck = _validateProviders(providers);
+		}
+
+		return new FIPSProviderStatus(
+			approvedMode, failedCheck, _getJSSEProviderName(), providerName,
+			providerOrder, providerVersion);
+	}
+
+	public static void validate() {
+		FIPSProviderStatus fipsProviderStatus = getStatus();
+
+		if (!fipsProviderStatus.isValid()) {
+			throw new SecurityException(fipsProviderStatus.getFailedCheck());
+		}
 
 		_validatePasswordsEncryptionAlgorithm(
 			PropsUtil.get(PropsKeys.PASSWORDS_ENCRYPTION_ALGORITHM));
 	}
 
-	private static void _validateFIPSProvider(Provider[] providers) {
+	private static String _getJSSEProviderName() {
+		try {
+			SSLContext sslContext = SSLContext.getInstance("TLS");
+
+			Provider provider = sslContext.getProvider();
+
+			return provider.getName();
+		}
+		catch (Exception exception) {
+			return null;
+		}
+	}
+
+	private static String _validateFIPSProvider(Provider[] providers) {
 		if (ArrayUtil.isEmpty(providers)) {
-			throw new SecurityException("There are no security providers");
+			return "There are no security providers";
 		}
 
 		Provider provider = providers[0];
@@ -51,8 +102,8 @@ public class FIPSModeValidator {
 		String name = provider.getName();
 
 		if (!_allowedProviderNames.containsKey(name)) {
-			throw new SecurityException(
-				"The first security provider must be an allowed FIPS provider");
+			return "The first security provider must be an allowed FIPS " +
+				"provider";
 		}
 
 		try {
@@ -70,16 +121,13 @@ public class FIPSModeValidator {
 				Method isFIPSMethod = ReflectionUtil.getDeclaredMethod(
 					providerClass, "isFips");
 
-				if (!GetterUtil.getBoolean(
-						isExperimentalFIPSMethod.invoke(provider)) &&
-					GetterUtil.getBoolean(isFIPSMethod.invoke(provider))) {
+				if (GetterUtil.getBoolean(
+						isExperimentalFIPSMethod.invoke(provider)) ||
+					!GetterUtil.getBoolean(isFIPSMethod.invoke(provider))) {
 
-					return;
+					return "AmazonCorrettoCryptoProvider must be a " +
+						"nonexperimental FIPS build";
 				}
-
-				throw new SecurityException(
-					"AmazonCorrettoCryptoProvider must be a nonexperimental " +
-						"FIPS build");
 			}
 			else if (Objects.equals(name, "BCFIPS")) {
 				Class<?> providerClass = provider.getClass();
@@ -96,8 +144,7 @@ public class FIPSModeValidator {
 				if (!GetterUtil.getBoolean(
 						isInApprovedOnlyModeMethod.invoke(null))) {
 
-					throw new SecurityException(
-						"BCFIPS is not in approved only mode");
+					return "BCFIPS is not in approved only mode";
 				}
 
 				Class<?> fipsStatusClass = Class.forName(
@@ -112,14 +159,10 @@ public class FIPSModeValidator {
 						ReflectionUtil.getDeclaredMethod(
 							fipsStatusClass, "getStatusMessage");
 
-					throw new SecurityException(
-						"BCFIPS integrity self test failed: " +
-							getStatusMessageMethod.invoke(null));
+					return "BCFIPS integrity self test failed: " +
+						getStatusMessageMethod.invoke(null);
 				}
 			}
-		}
-		catch (SecurityException securityException) {
-			throw securityException;
 		}
 		catch (Throwable throwable) {
 			Throwable causeThrowable = throwable.getCause();
@@ -134,9 +177,10 @@ public class FIPSModeValidator {
 				message = causeThrowable.toString();
 			}
 
-			throw new SecurityException(
-				"FIPS provider integrity failed: " + message, causeThrowable);
+			return "FIPS provider integrity failed: " + message;
 		}
+
+		return null;
 	}
 
 	private static void _validatePasswordsEncryptionAlgorithm(
@@ -183,7 +227,7 @@ public class FIPSModeValidator {
 		}
 	}
 
-	private static void _validateProviders(Provider[] providers) {
+	private static String _validateProviders(Provider[] providers) {
 		Provider provider = providers[0];
 
 		List<String> allowedProviderNames = _allowedProviderNames.get(
@@ -196,13 +240,12 @@ public class FIPSModeValidator {
 				!allowedProviderNames.contains(curProvider.getName()));
 
 		if (ArrayUtil.isEmpty(notAllowedProviders)) {
-			return;
+			return null;
 		}
 
-		throw new SecurityException(
-			StringBundler.concat(
-				"The security providers ", Arrays.toString(notAllowedProviders),
-				" are not allowed in FIPS mode for ", provider.getName()));
+		return StringBundler.concat(
+			"The security providers ", Arrays.toString(notAllowedProviders),
+			" are not allowed in FIPS mode for ", provider.getName());
 	}
 
 	private static final int _PASSWORDS_ENCRYPTION_ALGORITHM_KEY_SIZE_MIN = 112;

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSProviderStatus.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSProviderStatus.java
@@ -1,0 +1,63 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import java.util.List;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSProviderStatus {
+
+	public FIPSProviderStatus(
+		boolean approvedMode, String failedCheck, String jsseProviderName,
+		String providerName, List<String> providerOrder,
+		String providerVersion) {
+
+		_approvedMode = approvedMode;
+		_failedCheck = failedCheck;
+		_jsseProviderName = jsseProviderName;
+		_providerName = providerName;
+		_providerOrder = providerOrder;
+		_providerVersion = providerVersion;
+	}
+
+	public String getFailedCheck() {
+		return _failedCheck;
+	}
+
+	public String getJSSEProviderName() {
+		return _jsseProviderName;
+	}
+
+	public String getProviderName() {
+		return _providerName;
+	}
+
+	public List<String> getProviderOrder() {
+		return _providerOrder;
+	}
+
+	public String getProviderVersion() {
+		return _providerVersion;
+	}
+
+	public boolean isApprovedMode() {
+		return _approvedMode;
+	}
+
+	public boolean isValid() {
+		return _failedCheck == null;
+	}
+
+	private final boolean _approvedMode;
+	private final String _failedCheck;
+	private final String _jsseProviderName;
+	private final String _providerName;
+	private final List<String> _providerOrder;
+	private final String _providerVersion;
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/packageinfo
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/packageinfo
@@ -1,1 +1,1 @@
-version 1.0.0
+version 1.1.0

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSModeValidatorTest.java
@@ -19,33 +19,35 @@ import org.junit.function.ThrowingRunnable;
 
 /**
  * @author Caio Farias
+ * @author Jorge García Jiménez
  */
 public class FIPSModeValidatorTest {
 
 	@Test
+	public void testGetStatus() {
+		FIPSProviderStatus fipsProviderStatus = FIPSModeValidator.getStatus();
+
+		Assert.assertNotNull(fipsProviderStatus.getProviderName());
+		Assert.assertFalse(
+			fipsProviderStatus.getProviderOrder(
+			).isEmpty());
+	}
+
+	@Test
 	public void testValidateFIPSProvider() {
 		for (String name : List.of("AmazonCorrettoCryptoProvider", "BCFIPS")) {
-			_assertSecurityException(
-				"FIPS provider integrity failed:",
-				() -> ReflectionTestUtil.invoke(
-					FIPSModeValidator.class, "_validateFIPSProvider",
-					new Class<?>[] {Provider[].class},
-					(Object)new Provider[] {_createProvider(name)}));
+			_assertFailedCheck(
+				"FIPS provider integrity failed:", "_validateFIPSProvider",
+				new Provider[] {_createProvider(name)});
 		}
 
-		_assertSecurityException(
+		_assertFailedCheck(
 			"The first security provider must be an allowed FIPS provider",
-			() -> ReflectionTestUtil.invoke(
-				FIPSModeValidator.class, "_validateFIPSProvider",
-				new Class<?>[] {Provider[].class},
-				(Object)new Provider[] {
-					_createProvider(RandomTestUtil.randomString())
-				}));
-		_assertSecurityException(
-			"There are no security providers",
-			() -> ReflectionTestUtil.invoke(
-				FIPSModeValidator.class, "_validateFIPSProvider",
-				new Class<?>[] {Provider[].class}, (Object)new Provider[0]));
+			"_validateFIPSProvider",
+			new Provider[] {_createProvider(RandomTestUtil.randomString())});
+		_assertFailedCheck(
+			"There are no security providers", "_validateFIPSProvider",
+			new Provider[0]);
 	}
 
 	@Test
@@ -90,16 +92,23 @@ public class FIPSModeValidatorTest {
 				FIPSModeValidator.class, "_allowedProviderNames");
 
 		for (String allowedProviderName : allowedProviderNames.keySet()) {
-			_assertSecurityException(
-				"are not allowed in FIPS mode for",
-				() -> ReflectionTestUtil.invoke(
-					FIPSModeValidator.class, "_validateProviders",
-					new Class<?>[] {Provider[].class},
-					(Object)new Provider[] {
-						_createProvider(allowedProviderName),
-						_createProvider(RandomTestUtil.randomString())
-					}));
+			_assertFailedCheck(
+				"are not allowed in FIPS mode for", "_validateProviders",
+				new Provider[] {
+					_createProvider(allowedProviderName),
+					_createProvider(RandomTestUtil.randomString())
+				});
 		}
+	}
+
+	private void _assertFailedCheck(
+		String expectedMessage, String methodName, Provider[] providers) {
+
+		String failedCheck = ReflectionTestUtil.invoke(
+			FIPSModeValidator.class, methodName,
+			new Class<?>[] {Provider[].class}, (Object)providers);
+
+		Assert.assertTrue(failedCheck, failedCheck.contains(expectedMessage));
 	}
 
 	private void _assertSecurityException(


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-93274

## What Is Being Fixed

`FIPSModeValidator` computes the security-provider integrity picture at boot, but it is a `static void`, throw-only method with no getters, so everything it learns is discarded. The Security Info Service (LPD-98192) and the other FIPS runtime-integrity subtasks need to read that picture, not just fail-fast on it.

## How It Is Being Fixed

Introduce an immutable `FIPSProviderStatus` result and extract `FIPSModeValidator.getStatus()` as a reusable producer that reads `Security.getProviders()`, resolves the provider name/version/order and the JSSE provider, and reports the approved-mode and failure-reason without throwing. `validate()` now delegates to `getStatus()` and throws only when the status is invalid, preserving the boot fail-fast, and it still applies the PBKDF2/SHA-256 password-encryption-algorithm check.

## Base

This branch is staged on top of LPD-94045 (already merged in the canonical repo), so its FIPS boot check merges cleanly with this refactor. When retargeted to the canonical master, those LPD-94045 commits drop out as already-applied, leaving only this refactor.

## Scope

The provider-stack-mismatch audit named in the ticket is deferred to LPD-98193 (the on-demand re-run / Error State subtask), where the runtime provider-stack re-check naturally lives.

## PR Check

**pr-check: SKIPPED** — Staging PR on a personal fork, to be retargeted to the canonical repo when ready.

<!-- pr-check {"reason": "Staging PR on a personal fork, to be retargeted to the canonical repo when ready.", "result": "skipped", "sha": "830739eb81a0ccc1b8e53dc55366a9ef01c60328"} -->

