### PR TITLE
LPD-93274 Add a FIPS application state machine

### DIFF
--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationState.java
@@ -1,0 +1,25 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+/**
+ * The states of Liferay DXP's FIPS application state machine.
+ *
+ * <p>
+ * The validated cryptographic provider maintains its own internal finite state
+ * machine. These states form an application level overlay that tracks Liferay
+ * DXP's relationship to that validated module, modeled per ISO/IEC 19790:2025
+ * §7.11.4 and the §2.2 application state machine.
+ * </p>
+ *
+ * @author Jorge García Jiménez
+ */
+public enum FIPSApplicationState {
+
+	ERROR, INITIALIZING, KEY_CSP_ENTRY, OPERATIONAL, POWER_OFF, QUIESCENT,
+	SELF_TEST
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachine.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachine.java
@@ -1,0 +1,85 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import com.liferay.petra.string.StringBundler;
+
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Tracks Liferay DXP's current {@link FIPSApplicationState} and enforces the
+ * legal transitions of the §2.2 application state machine.
+ *
+ * <p>
+ * The machine starts in {@link FIPSApplicationState#INITIALIZING} and only
+ * moves along an allowed edge; an illegal transition is rejected with an
+ * {@link IllegalStateException} and leaves the current state unchanged.
+ * {@link FIPSApplicationState#ERROR} is latched to a single
+ * {@link FIPSApplicationState#POWER_OFF} exit and
+ * {@link FIPSApplicationState#POWER_OFF} is terminal, so an error state is left
+ * only by restarting the portal (see §2.4).
+ * </p>
+ *
+ * <p>
+ * Each successful transition is the seam where FIPS state transition audit
+ * events are recorded (see §5.2).
+ * </p>
+ *
+ * @author Jorge García Jiménez
+ */
+public class FIPSApplicationStateMachine {
+
+	public FIPSApplicationState getFIPSApplicationState() {
+		return _fipsApplicationState;
+	}
+
+	public synchronized void transition(
+		FIPSApplicationState fipsApplicationState) {
+
+		Set<FIPSApplicationState> nextFIPSApplicationStates =
+			_allowedTransitions.get(_fipsApplicationState);
+
+		if (!nextFIPSApplicationStates.contains(fipsApplicationState)) {
+			throw new IllegalStateException(
+				StringBundler.concat(
+					"Unable to transition the FIPS application state from \"",
+					_fipsApplicationState, "\" to \"", fipsApplicationState,
+					"\""));
+		}
+
+		_fipsApplicationState = fipsApplicationState;
+	}
+
+	private static final Map<FIPSApplicationState, Set<FIPSApplicationState>>
+		_allowedTransitions = Map.of(
+			FIPSApplicationState.ERROR, Set.of(FIPSApplicationState.POWER_OFF),
+			FIPSApplicationState.INITIALIZING,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.POWER_OFF,
+				FIPSApplicationState.SELF_TEST),
+			FIPSApplicationState.KEY_CSP_ENTRY,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
+				FIPSApplicationState.POWER_OFF),
+			FIPSApplicationState.OPERATIONAL,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.KEY_CSP_ENTRY,
+				FIPSApplicationState.POWER_OFF, FIPSApplicationState.QUIESCENT),
+			FIPSApplicationState.POWER_OFF, Set.of(),
+			FIPSApplicationState.QUIESCENT,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
+				FIPSApplicationState.POWER_OFF),
+			FIPSApplicationState.SELF_TEST,
+			Set.of(
+				FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL,
+				FIPSApplicationState.POWER_OFF));
+
+	private volatile FIPSApplicationState _fipsApplicationState =
+		FIPSApplicationState.INITIALIZING;
+
+}

--- a/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineTest.java
+++ b/portal-kernel/test/unit/com/liferay/portal/kernel/security/fips/FIPSApplicationStateMachineTest.java
@@ -1,0 +1,116 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.portal.kernel.security.fips;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSApplicationStateMachineTest {
+
+	@Test
+	public void testAllowedTransitions() {
+		FIPSApplicationStateMachine fipsApplicationStateMachine =
+			new FIPSApplicationStateMachine();
+
+		Assert.assertEquals(
+			FIPSApplicationState.INITIALIZING,
+			fipsApplicationStateMachine.getFIPSApplicationState());
+
+		_assertAllowedTransition(
+			fipsApplicationStateMachine, FIPSApplicationState.SELF_TEST);
+		_assertAllowedTransition(
+			fipsApplicationStateMachine, FIPSApplicationState.OPERATIONAL);
+		_assertAllowedTransition(
+			fipsApplicationStateMachine, FIPSApplicationState.KEY_CSP_ENTRY);
+		_assertAllowedTransition(
+			fipsApplicationStateMachine, FIPSApplicationState.OPERATIONAL);
+		_assertAllowedTransition(
+			fipsApplicationStateMachine, FIPSApplicationState.QUIESCENT);
+		_assertAllowedTransition(
+			fipsApplicationStateMachine, FIPSApplicationState.OPERATIONAL);
+		_assertAllowedTransition(
+			fipsApplicationStateMachine, FIPSApplicationState.ERROR);
+		_assertAllowedTransition(
+			fipsApplicationStateMachine, FIPSApplicationState.POWER_OFF);
+	}
+
+	@Test
+	public void testIllegalTransitions() {
+		_assertIllegalTransition(
+			FIPSApplicationState.ERROR, FIPSApplicationState.OPERATIONAL);
+		_assertIllegalTransition(
+			FIPSApplicationState.INITIALIZING,
+			FIPSApplicationState.OPERATIONAL);
+		_assertIllegalTransition(
+			FIPSApplicationState.OPERATIONAL,
+			FIPSApplicationState.INITIALIZING);
+		_assertIllegalTransition(
+			FIPSApplicationState.POWER_OFF, FIPSApplicationState.INITIALIZING);
+		_assertIllegalTransition(
+			FIPSApplicationState.SELF_TEST, FIPSApplicationState.KEY_CSP_ENTRY);
+	}
+
+	private void _assertAllowedTransition(
+		FIPSApplicationStateMachine fipsApplicationStateMachine,
+		FIPSApplicationState fipsApplicationState) {
+
+		fipsApplicationStateMachine.transition(fipsApplicationState);
+
+		Assert.assertEquals(
+			fipsApplicationState,
+			fipsApplicationStateMachine.getFIPSApplicationState());
+	}
+
+	private void _assertIllegalTransition(
+		FIPSApplicationState fromFIPSApplicationState,
+		FIPSApplicationState toFIPSApplicationState) {
+
+		FIPSApplicationStateMachine fipsApplicationStateMachine =
+			_createFIPSApplicationStateMachine(fromFIPSApplicationState);
+
+		Assert.assertThrows(
+			IllegalStateException.class,
+			() -> fipsApplicationStateMachine.transition(
+				toFIPSApplicationState));
+
+		Assert.assertEquals(
+			fromFIPSApplicationState,
+			fipsApplicationStateMachine.getFIPSApplicationState());
+	}
+
+	private FIPSApplicationStateMachine _createFIPSApplicationStateMachine(
+		FIPSApplicationState fipsApplicationState) {
+
+		FIPSApplicationStateMachine fipsApplicationStateMachine =
+			new FIPSApplicationStateMachine();
+
+		if (fipsApplicationState == FIPSApplicationState.INITIALIZING) {
+			return fipsApplicationStateMachine;
+		}
+
+		if ((fipsApplicationState == FIPSApplicationState.ERROR) ||
+			(fipsApplicationState == FIPSApplicationState.POWER_OFF) ||
+			(fipsApplicationState == FIPSApplicationState.SELF_TEST)) {
+
+			fipsApplicationStateMachine.transition(fipsApplicationState);
+
+			return fipsApplicationStateMachine;
+		}
+
+		fipsApplicationStateMachine.transition(FIPSApplicationState.SELF_TEST);
+		fipsApplicationStateMachine.transition(FIPSApplicationState.OPERATIONAL);
+
+		if (fipsApplicationState != FIPSApplicationState.OPERATIONAL) {
+			fipsApplicationStateMachine.transition(fipsApplicationState);
+		}
+
+		return fipsApplicationStateMachine;
+	}
+
+}


### PR DESCRIPTION
Staging PR for manual review — **LPD-93274** (§2.2 FIPS application state machine engine). Not pr-checked yet.

Adds the FSM engine primitive to `portal-kernel`:

- **`FIPSApplicationState`** — the 7 states: `INITIALIZING`, `SELF_TEST`, `OPERATIONAL`, `KEY_CSP_ENTRY`, `QUIESCENT`, `ERROR`, `POWER_OFF`, each documented per §2.2 / §7.11.4.
- **`FIPSApplicationStateMachine`** — a thread-safe current-state holder (starts `INITIALIZING`), a guarded `transition(...)` that enforces the legal transition table and rejects illegal moves with `IllegalStateException` (leaving state unchanged), and `getFIPSApplicationState()`. `ERROR` is latched to a single `POWER_OFF` exit per §2.4; `POWER_OFF` is terminal. The transition method is the seam where §5.2 (LPD-93284) will record audit events.
- **`FIPSApplicationStateMachineTest`** — the legal lifecycle path plus 5 illegal-transition cases.

**Scope: the engine only (AC3).** Deferred to their own increments: boot-lifecycle wiring (**LPD-99217**), transition logging (§5.2 / LPD-93284), the REST read (§2.1), the per-service approved-function indicators (AC2), and Self-Test / Quiescent request gating (AC4 / AC5).

Dev TT **LPD-99216**. brian-fixer converged (2 rounds; ~15% Brian-reject estimate — the only escalation was the `_assertTransition` param order, kept receiver-first). Two signed commits (logic + test). Java unit test passes 2/2.
