### PR TITLE
LPD-98316 Record a rejected federation token in the FIPS audit log

### DIFF
--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/audit/FIPSFederationTokenAuditUtil.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/audit/FIPSFederationTokenAuditUtil.java
@@ -1,0 +1,65 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.rest.internal.audit;
+
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.security.fips.FIPSApplicationState;
+import com.liferay.portal.kernel.security.fips.FIPSApplicationStateMachineUtil;
+import com.liferay.portal.kernel.security.fips.FIPSAuditEvent;
+import com.liferay.portal.kernel.security.fips.FIPSAuditUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+
+import jakarta.servlet.http.HttpServletRequest;
+
+import org.apache.cxf.jaxrs.utils.JAXRSUtils;
+import org.apache.cxf.message.Message;
+import org.apache.cxf.transport.http.AbstractHTTPDestination;
+
+/**
+ * @author Jorge García Jiménez
+ */
+public class FIPSFederationTokenAuditUtil {
+
+	public static void writeFederationTokenRejected(
+		String issuer, String offendingValue) {
+
+		if (!PropsValues.FIPS_ENABLED) {
+			return;
+		}
+
+		FIPSApplicationState fipsApplicationState =
+			FIPSApplicationStateMachineUtil.getFIPSApplicationState();
+
+		FIPSAuditEvent fipsAuditEvent = new FIPSAuditEvent(
+			"federation-token-rejected", FIPSAuditEvent.Severity.WARNING);
+
+		fipsAuditEvent.put("fips-state", fipsApplicationState.name());
+		fipsAuditEvent.put("offending-value", offendingValue);
+		fipsAuditEvent.put("receiving-endpoint", _getReceivingEndpoint());
+		fipsAuditEvent.put("token-issuer", issuer);
+		fipsAuditEvent.put("token-type", "JWT");
+
+		FIPSAuditUtil.write(fipsAuditEvent);
+	}
+
+	private static String _getReceivingEndpoint() {
+		Message message = JAXRSUtils.getCurrentMessage();
+
+		if (message == null) {
+			return StringPool.BLANK;
+		}
+
+		HttpServletRequest httpServletRequest = (HttpServletRequest)message.get(
+			AbstractHTTPDestination.HTTP_REQUEST);
+
+		if (httpServletRequest == null) {
+			return StringPool.BLANK;
+		}
+
+		return httpServletRequest.getRequestURI();
+	}
+
+}

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/authentication/handler/LiferayJWTBearerAuthenticationHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/authentication/handler/LiferayJWTBearerAuthenticationHandler.java
@@ -5,6 +5,7 @@
 
 package com.liferay.oauth2.provider.rest.internal.endpoint.access.token.authentication.handler;
 
+import com.liferay.oauth2.provider.rest.internal.audit.FIPSFederationTokenAuditUtil;
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.util.OAuth2JWKValidatorUtil;
 import com.liferay.portal.kernel.log.Log;
@@ -117,8 +118,19 @@ public class LiferayJWTBearerAuthenticationHandler
 		String tokenEndpointAuthMethod = client.getTokenEndpointAuthMethod();
 
 		try {
-			OAuth2JWKValidatorUtil.validateJWSAlgorithm(
-				(String)jwtToken.getJwsHeader(JoseConstants.HEADER_ALGORITHM));
+			String algorithm = (String)jwtToken.getJwsHeader(
+				JoseConstants.HEADER_ALGORITHM);
+
+			try {
+				OAuth2JWKValidatorUtil.validateJWSAlgorithm(algorithm);
+			}
+			catch (SecurityException securityException) {
+				FIPSFederationTokenAuditUtil.writeFederationTokenRejected(
+					(String)jwtToken.getClaim(JwtConstants.CLAIM_ISSUER),
+					algorithm);
+
+				throw securityException;
+			}
 
 			if (tokenEndpointAuthMethod.equals("client_secret_jwt")) {
 				String clientSecret = client.getClientSecret();

--- a/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayJWTBearerGrantHandler.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-rest/src/main/java/com/liferay/oauth2/provider/rest/internal/endpoint/access/token/grant/handler/LiferayJWTBearerGrantHandler.java
@@ -6,6 +6,7 @@
 package com.liferay.oauth2.provider.rest.internal.endpoint.access.token.grant.handler;
 
 import com.liferay.oauth2.provider.configuration.OAuth2ProviderConfiguration;
+import com.liferay.oauth2.provider.rest.internal.audit.FIPSFederationTokenAuditUtil;
 import com.liferay.oauth2.provider.rest.internal.configuration.OAuth2InAssertionConfiguration;
 import com.liferay.oauth2.provider.rest.internal.endpoint.constants.OAuth2ProviderRESTEndpointConstants;
 import com.liferay.oauth2.provider.rest.internal.endpoint.liferay.LiferayOAuthDataProvider;
@@ -255,8 +256,19 @@ public class LiferayJWTBearerGrantHandler extends BaseAccessTokenGrantHandler {
 
 				JwsHeaders jwsHeaders = jwtToken.getJwsHeaders();
 
-				OAuth2JWKValidatorUtil.validateJWSAlgorithm(
-					jwsHeaders.getAlgorithm());
+				try {
+					OAuth2JWKValidatorUtil.validateJWSAlgorithm(
+						jwsHeaders.getAlgorithm());
+				}
+				catch (SecurityException securityException) {
+					JwtClaims rejectedJwtClaims = jwtToken.getClaims();
+
+					FIPSFederationTokenAuditUtil.writeFederationTokenRejected(
+						rejectedJwtClaims.getIssuer(),
+						jwsHeaders.getAlgorithm());
+
+					throw securityException;
+				}
 
 				JwtClaims jwtClaims = jwtToken.getClaims();
 

--- a/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/FIPSFederationTokenAuditTest.java
+++ b/modules/apps/oauth2-provider/oauth2-provider-test/src/testIntegration/java/com/liferay/oauth2/provider/token/endpoint/test/FIPSFederationTokenAuditTest.java
@@ -1,0 +1,112 @@
+/**
+ * SPDX-FileCopyrightText: (c) 2026 Liferay, Inc. https://liferay.com
+ * SPDX-License-Identifier: LGPL-2.1-or-later OR LicenseRef-Liferay-DXP-EULA-2.0.0-2023-06
+ */
+
+package com.liferay.oauth2.provider.token.endpoint.test;
+
+import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
+import com.liferay.oauth2.provider.internal.test.PasswordAuthorizationGrant;
+import com.liferay.petra.lang.SafeCloseable;
+import com.liferay.portal.kernel.model.User;
+import com.liferay.portal.kernel.test.util.PropsValuesTestUtil;
+import com.liferay.portal.kernel.test.util.TestPropsValues;
+import com.liferay.portal.kernel.test.util.UserTestUtil;
+import com.liferay.portal.kernel.util.PropsValues;
+import com.liferay.portal.test.log.LogCapture;
+import com.liferay.portal.test.log.LoggerTestUtil;
+
+import jakarta.ws.rs.core.Response;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import org.osgi.framework.BundleActivator;
+
+/**
+ * @author Jorge García Jiménez
+ */
+@RunWith(Arquillian.class)
+public class FIPSFederationTokenAuditTest extends BaseTokenEndpointTestCase {
+
+	@Test
+	public void testRejectedClientAssertionIsAudited() throws Exception {
+		try (SafeCloseable safeCloseable =
+				PropsValuesTestUtil.swapWithSafeCloseable("FIPS_ENABLED", true);
+			LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_LOGGER_NAME, LoggerTestUtil.WARN)) {
+
+			Response response = _getTokenResponse();
+
+			Assert.assertEquals(401, response.getStatus());
+
+			List<String> messages = _getFIPSAuditLogEntryMessages(logCapture);
+
+			Assert.assertEquals(messages.toString(), 1, messages.size());
+
+			String message = messages.get(0);
+
+			_assertField("fips-state=", message);
+			_assertField("offending-value=HS256", message);
+			_assertField("receiving-endpoint=/o/oauth2/token", message);
+			_assertField("token-issuer=" + TEST_CLIENT_ID_2, message);
+			_assertField("token-type=JWT", message);
+		}
+	}
+
+	@Test
+	public void testRejectedClientAssertionIsNotAuditedOutsideFIPSMode()
+		throws Exception {
+
+		try (LogCapture logCapture = LoggerTestUtil.configureLog4JLogger(
+				_LOGGER_NAME, LoggerTestUtil.WARN)) {
+
+			Response response = _getTokenResponse();
+
+			Assert.assertEquals(200, response.getStatus());
+
+			List<String> messages = _getFIPSAuditLogEntryMessages(logCapture);
+
+			Assert.assertTrue(messages.isEmpty());
+		}
+	}
+
+	@Override
+	protected BundleActivator getBundleActivator() {
+		return new TestPreparatorBundleActivator() {
+		};
+	}
+
+	private void _assertField(String field, String message) {
+		Assert.assertTrue(message.contains(field));
+	}
+
+	private List<String> _getFIPSAuditLogEntryMessages(LogCapture logCapture) {
+		List<String> messages = new ArrayList<>();
+
+		for (String message : logCapture.getMessages()) {
+			if (message.contains("event-type=federation-token-rejected")) {
+				messages.add(message);
+			}
+		}
+
+		return messages;
+	}
+
+	private Response _getTokenResponse() throws Exception {
+		User user = UserTestUtil.getAdminUser(TestPropsValues.getCompanyId());
+
+		return getTokenResponse(
+			new PasswordAuthorizationGrant(
+				user.getEmailAddress(), PropsValues.DEFAULT_ADMIN_PASSWORD),
+			clientAuthentications.get(TEST_CLIENT_ID_2));
+	}
+
+	private static final String _LOGGER_NAME =
+		"com.liferay.portal.kernel.internal.log4j.FIPSLog4jUtil";
+
+}

--- a/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/internal/log4j/FIPSLog4jUtil.java
@@ -49,6 +49,10 @@ public class FIPSLog4jUtil {
 			return Level.ERROR;
 		}
 
+		if (severity == FIPSAuditEvent.Severity.WARNING) {
+			return Level.WARN;
+		}
+
 		return Level.INFO;
 	}
 

--- a/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/security/fips/FIPSAuditEvent.java
@@ -46,7 +46,7 @@ public class FIPSAuditEvent {
 
 	public enum Severity {
 
-		CRITICAL, INFO
+		CRITICAL, INFO, WARNING
 
 	}
 


### PR DESCRIPTION
https://liferay.atlassian.net/browse/LPD-98316

**Review branch, not for merge.** The base is `LPD-93284-fips-audit-log-3` rather than `master` so the diff shows only the LPD-98316 work. The emitter this consumes is not on `master` yet — it is forwarded as liferay-appsec#3245 / brianchandotcom#180553 — and the appsec bot closes a pull request whose base is another ticket's branch, so this stays on the fork until LPD-93284 merges and this can be rebased onto `master`.

## What Is Being Fixed

An inbound federation token rejected for a nonconforming signature algorithm left no evidence behind. An operator could not tell from the audit trail that the FIPS algorithm allow list had turned a token away, which is LPD-93648 AC8.

## How It Is Being Fixed

Both JWT reject paths — the client-assertion authentication handler and the JWT bearer grant handler — catch the `SecurityException` that `OAuth2JWKValidatorUtil.validateJWSAlgorithm` throws, write a `federation-token-rejected` event, then rethrow, so the rejection behaviour itself is untouched. The event carries the refused algorithm identifier, the issuer that presented the token, the endpoint that received it and the current FIPS state, on top of the common envelope the shared emitter builds.

The record holds the offending algorithm identifier only. The token, its key and its signature material never reach it, which is what ISO/IEC 19790 7.6.3 [AS06.28] asks of an audit record. The write is skipped outside FIPS mode, and the rejection deliberately does not move the §2.2 state machine, because turning away external data is normal operation rather than an error state.

`FIPSAuditEvent.Severity` gains `WARNING`. A rejected token is neither an error state nor routine information, so the two existing levels left no honest choice. The level mapping in `FIPSLog4jUtil` had to move with it: everything that was not `CRITICAL` resolved to `INFO`, so a warning would have been recorded a level below what it is, and the test asserting at `WARN` would have failed with no obvious cause.

## Ported Rather Than Written

This supersedes the original `LPD-98316-federation-token-rejected` branch, whose base is 1206 commits behind `master` and whose lower 27 commits are a superseded draft of the LPD-93284 stack, including the 406 line `FIPSAuditEventEmitterUtil` that has since become `FIPSAuditUtil` plus `FIPSLog4jUtil`. Only the four LPD-98316 commits were worth keeping, and three things had to be rewired against the API that actually shipped:

- `FIPSAuditEventEmitterUtil.emit` became `FIPSAuditUtil.write`, so `emitFederationTokenRejected` is now `writeFederationTokenRejected`.
- `FIPSApplicationState.getValue()` was dropped from the enum during review, so the state is recorded with `name()`.
- `_fetchReceivingEndpoint` could return null on both early exits, and the shipped `put` rejects a null value outright, so it would have thrown on any call outside a CXF request. It is now `_getReceivingEndpoint` returning `StringPool.BLANK`, which follows the `fetch` nullable and `get` non-null convention, keeps the five `put` calls one sorted block, and leaves the record with a stable field set.

## Testing

`FIPSFederationTokenAuditTest` drives the token endpoint with a client assertion signed by a nonconforming algorithm and reads the event back off the writer's own logger, so it covers the emission path rather than the helper in isolation. The companion case runs the same request outside FIPS mode and asserts the log stays empty.

The 33 existing FIPS unit tests still pass with the new severity in place: `FIPSApplicationStateMachineUtilTest` 13, `FIPSAuditNDJSONLayoutTest` 8, `FIPSAuditUtilTest` 5, `FIPSAuditEventTest` 4, `FIPSAuditFilterTest` 3.

The integration test has not been executed yet — it needs a deployed bundle with FIPS enabled. The acceptance criteria also ask for verification in the FIPS CI environment, which is LPD-80674 and still open, so that criterion cannot close here.
